### PR TITLE
Fix crash about Proxy Password

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -64,7 +64,7 @@ export const isInvalidHeader = (name, value) => {
  * @ignore
  */
 export const parseUrl = (url) => {
-    const parsed = urlModule.parse(url);
+    const parsed = new URL(url);
 
     parsed.username = null;
     parsed.password = null;


### PR DESCRIPTION
When Proxy Password has special characters it crashes and the function `url.parse()` is deprecated, so I modified to a constructor and now Proxy Password can have special characters.