### PR TITLE
Improving parseUrl() to handle IPv6 and other special URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,10 @@ If the callback is not provided, the function returns a promise instead.
 
 ### `parseUrl(url)`
 
-Calls Node.js's [url.parse](https://nodejs.org/docs/latest/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost)
-function and extends the resulting object with the following fields: `scheme`, `username` and `password`.
-For example, for `HTTP://bob:pass123@example.com` these values are
-`http`, `bob` and `pass123`, respectively.
+Parses url string with `new URL(url)` and normalizes the result (eg. port is converted to number), path (ie. pathname + search) is added
+to the result.
 
+For non-urls the given string is treated as if it was relative url.
 
 ### `redactUrl(url, passwordReplacement)`
 

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -19,7 +19,7 @@ export const anonymizeProxy = (proxyUrl, callback) => {
     if (!parsedProxyUrl.host || !parsedProxyUrl.port) {
         throw new Error('Invalid "proxyUrl" option: the URL must contain both hostname and port.');
     }
-    if (parsedProxyUrl.scheme !== 'http') {
+    if (parsedProxyUrl.protocol !== 'http:') {
         throw new Error('Invalid "proxyUrl" option: only HTTP proxies are currently supported.');
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -311,9 +311,9 @@ export class Server extends EventEmitter {
                                 `Invalid "upstreamProxyUrl" provided: URL must have hostname and port (was "${funcResult.upstreamProxyUrl}")`,
                             );
                         }
-                        if (handlerOpts.upstreamProxyUrlParsed.scheme !== 'http') {
+                        if (handlerOpts.upstreamProxyUrlParsed.protocol !== 'http:') {
                             throw new Error(
-                                `Invalid "upstreamProxyUrl" provided: URL must have the "http" scheme (was "${funcResult.upstreamProxyUrl}")`,
+                                `Invalid "upstreamProxyUrl" provided: URL must have the "http" protocol (was "${funcResult.upstreamProxyUrl}")`,
                             );
                         }
                     }

--- a/src/tcp_tunnel_tools.js
+++ b/src/tcp_tunnel_tools.js
@@ -11,7 +11,7 @@ export function createTunnel(proxyUrl, targetHost, providedOptions = {}, callbac
 
     const parsedProxyUrl = parseUrl(proxyUrl);
     if (!parsedProxyUrl.hostname) throw new Error('proxyUrl needs to include atleast hostname');
-    if (parsedProxyUrl.scheme !== 'http') throw new Error('Currently only "http" scheme is supported');
+    if (parsedProxyUrl.protocol !== 'http:') throw new Error('Currently only "http" protocol is supported');
 
     const options = {
         verbose: false,

--- a/src/tools.js
+++ b/src/tools.js
@@ -59,7 +59,8 @@ export const isInvalidHeader = (name, value) => {
  * Wraps `new URL(url)` and adds following:
  *  - `port` is casted to number / null from string
  *  - `path` field is added (pathname + search)
- *  - malformed or relative urls are parsed as well
+ *  - malformed or relative urls are parsed as well (always, the given string is returned as is in
+ *    few fields, other are left undefined)
  *
  * Using `new URL` causes following:
  *  - we are unable to distiguish empty password and missing password

--- a/src/tools.js
+++ b/src/tools.js
@@ -64,29 +64,32 @@ export const isInvalidHeader = (name, value) => {
  * @ignore
  */
 export const parseUrl = (url) => {
-    const parsed = urlModule.parse(url);
+    // NOTE: Not using url.parse() because it can't handle IPv6 and other special URLs
+    const urlObj = new URL(url);
 
-    parsed.username = null;
-    parsed.password = null;
+    const parsed = {
+        hash: urlObj.hash,
+        host: urlObj.host,
+        hostname: urlObj.hostname,
+        href: urlObj.href,
+        origin: urlObj.origin,
+        password: urlObj.password,
+        pathname: urlObj.pathname,
+        port: urlObj.port,
+        protocol: urlObj.protocol,
+        search: urlObj.search,
+        searchParams: urlObj.searchParams,
+        username: urlObj.username,
+    };
+
+    console.dir({ parsed });
+
     parsed.scheme = null;
-
-    if (parsed.auth) {
-        const matches = /^([^:]+)(:?)(.*)$/.exec(parsed.auth);
-        if (matches && matches.length === 4) {
-            parsed.username = matches[1];
-            if (matches[2] === ':') parsed.password = matches[3];
-        }
-    }
-
     if (parsed.protocol) {
         const matches = /^([a-z0-9]+):$/i.exec(parsed.protocol);
         if (matches && matches.length === 2) {
             parsed.scheme = matches[1];
         }
-    }
-
-    if (parsed.port) {
-        parsed.port = parseInt(parsed.port, 10);
     }
 
     return parsed;
@@ -116,7 +119,7 @@ export const redactParsedUrl = (parsedUrl, passwordReplacement = '<redacted>') =
             auth = `${p.username}`;
         }
     }
-    return `${p.protocol}//${auth || ''}${auth ? '@' : ''}${p.host}${p.path || ''}${p.hash || ''}`;
+    return `${p.protocol}//${auth || ''}${auth ? '@' : ''}${p.host}${p.pathname || ''}${p.hash || ''}`;
 };
 
 const PROXY_AUTH_HEADER_REGEX = /^([a-z0-9-]+) ([a-z0-9+/=]+)$/i;

--- a/test/tools.js
+++ b/test/tools.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-const urlModule = require('url');
 const { expect } = require('chai');
 const net = require('net');
 const portastic = require('portastic');
@@ -11,59 +9,90 @@ const {
 
 /* global process, describe, it */
 
-
-const testUrl = (url, extras) => {
+const testUrl = (url, expected) => {
     const parsed1 = parseUrl(url);
-    // TODO: This test needs to be fixed
-    const parsed2 = urlModule.parse(url);
-    expect(parsed1).to.eql(_.extend(parsed2, extras));
+    expect(parsed1).to.contain(expected);
 };
 
 describe('tools.parseUrl()', () => {
     it('works', () => {
         testUrl('https://username:password@www.example.com:12345/some/path', {
-            scheme: 'https',
+            protocol: 'https:',
             username: 'username',
             password: 'password',
             port: 12345,
         });
 
+        testUrl('https://username:password@www.example.com/some/path', {
+            protocol: 'https:',
+            username: 'username',
+            password: 'password',
+            port: null,
+        });
+
         testUrl('http://us-er+na12345me:@www.example.com:12345/some/path', {
-            scheme: 'http',
+            protocol: 'http:',
             username: 'us-er+na12345me',
             password: '',
             port: 12345,
         });
 
         testUrl('socks5://username@www.example.com:12345/some/path', {
-            scheme: 'socks5',
+            protocol: 'socks5:',
             username: 'username',
-            password: null,
+            password: '',
             port: 12345,
         });
 
         testUrl('FTP://@www.example.com:12345/some/path', {
-            scheme: 'ftp',
-            username: null,
-            password: null,
+            protocol: 'ftp:',
+            username: '',
+            password: '',
             port: 12345,
         });
 
         testUrl('HTTP://www.example.com:12345/some/path', {
-            scheme: 'http',
-            username: null,
-            password: null,
+            protocol: 'http:',
+            username: '',
+            password: '',
             port: 12345,
         });
 
         testUrl('HTTP://www.example.com/some/path', {
-            scheme: 'http',
-            username: null,
-            password: null,
+            protocol: 'http:',
+            username: '',
+            password: '',
             port: null,
         });
 
-        // TODO: Added tests for IPv6 and the other failing URLs
+        testUrl('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/', {
+            protocol: 'http:',
+            username: '',
+            password: '',
+            port: null,
+        });
+
+        testUrl('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/', {
+            protocol: 'http:',
+            username: '',
+            password: '',
+            port: 12345,
+        });
+
+        testUrl('http://username:password@[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/', {
+            protocol: 'http:',
+            username: 'username',
+            password: 'password',
+            port: 12345,
+        });
+
+        // TODO: Maybe decoding password should be considered in parse url
+        testUrl('http://username:p@%%w0rd@[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/', {
+            protocol: 'http:',
+            username: 'username',
+            password: 'p%40%%w0rd',
+            port: 12345,
+        });
     });
 });
 
@@ -87,6 +116,9 @@ describe('tools.redactUrl()', () => {
 
         expect(redactUrl('ftp://example.com/'))
             .to.eql('ftp://example.com/');
+
+        expect(redactUrl('http://username:p@%%w0rd@[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/'))
+            .to.eql('http://username:<redacted>@[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/');
     });
 });
 

--- a/test/tools.js
+++ b/test/tools.js
@@ -14,6 +14,21 @@ const testUrl = (url, expected) => {
     expect(parsed1).to.contain(expected);
 };
 
+const testNonOrRelativeUrl = (url) => {
+    // Relative paths should be parsed, but only contain
+    // few selected fields
+    const parsedRelativeUrl = parseUrl(url);
+    expect(parsedRelativeUrl).to.contain({
+        path: url,
+    });
+    // eslint-disable-next-line no-unused-expressions
+    expect(!parsedRelativeUrl.protocol).to.be.true;
+    // eslint-disable-next-line no-unused-expressions
+    expect(!parsedRelativeUrl.host).to.be.true;
+    // eslint-disable-next-line no-unused-expressions
+    expect(!parsedRelativeUrl.port).to.be.true;
+};
+
 describe('tools.parseUrl()', () => {
     it('works', () => {
         testUrl('https://username:password@www.example.com:12345/some/path', {
@@ -93,6 +108,9 @@ describe('tools.parseUrl()', () => {
             password: 'p%40%%w0rd',
             port: 12345,
         });
+
+        testNonOrRelativeUrl('/some-relative-url?a=1');
+        testNonOrRelativeUrl('A nonsense, really.');
     });
 });
 

--- a/test/tools.js
+++ b/test/tools.js
@@ -14,6 +14,7 @@ const {
 
 const testUrl = (url, extras) => {
     const parsed1 = parseUrl(url);
+    // TODO: This test needs to be fixed
     const parsed2 = urlModule.parse(url);
     expect(parsed1).to.eql(_.extend(parsed2, extras));
 };
@@ -61,6 +62,8 @@ describe('tools.parseUrl()', () => {
             password: null,
             port: null,
         });
+
+        // TODO: Added tests for IPv6 and the other failing URLs
     });
 });
 

--- a/test/tools.js
+++ b/test/tools.js
@@ -69,7 +69,8 @@ describe('tools.parseUrl()', () => {
 
 describe('tools.redactUrl()', () => {
     it('works', () => {
-        expect(redactUrl('https://username:password@www.example.com:1234/path#hash'))
+        // Test that the function lower-cases the schema and path
+        expect(redactUrl('HTTPS://username:password@WWW.EXAMPLE.COM:1234/path#hash'))
             .to.eql('https://username:<redacted>@www.example.com:1234/path#hash');
 
         expect(redactUrl('https://username@www.example.com:1234/path#hash'))


### PR DESCRIPTION
Actually, looking at it, it might be best to just get rid of `parseUrl` completely and use `new URL()`, it only adds `scheme` to the parsed object which can be easily replaced by `protocol` around the code base