### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-preset-stage-0": "^6.1.18",
     "basic-auth": "^2.0.0",
     "body-parser": "^1.18.2",
-    "chai": "^4.0.2",
+    "chai": "^4.3.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "sinon": "^9.0.0",
     "sinon-stub-promise": "^4.0.0",
     "through": "^2.3.8",
-    "ws": "^7.1.2"
+    "ws": "^7.4.3"
   },
   "optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "basic-auth": "^2.0.0",
     "body-parser": "^1.18.2",
     "chai": "^4.0.2",
-    "eslint": "^7.13.0",
+    "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
Three packages were updated ~~(minor or patch versions only)~~ (now I realize that `npm outdated` does not work here as I expected with `package-lock.json` not being versioned. But this should not be problem nevertheless)
 - `eslint`
 - `chai`
 - `ws`

All of them are dev dependencies, `ws` is only used in tests. All unit tests pass.

Resolves apify/apify-core#1339