### PR TITLE
fix: remove dependency on node's `_http_common` module

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,3 @@
-import { _checkIsHttpToken, _checkInvalidHeaderChar } from '_http_common'; // eslint-disable-line
-
 const HOST_HEADER_REGEX = /^((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]))(:([0-9]+))?$/;
 
 /**
@@ -42,15 +40,35 @@ const HOP_BY_HOP_HEADERS_REGEX = new RegExp(`^(${HOP_BY_HOP_HEADERS.join('|')})$
 
 export const isHopByHopHeader = (header) => HOP_BY_HOP_HEADERS_REGEX.test(header);
 
+const TOKEN_REGEX = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
+
+/**
+ * Verifies that the given val is a valid HTTP token per the rules defined in RFC 7230
+ * @see https://tools.ietf.org/html/rfc7230#section-3.2.6
+ * @see https://github.com/nodejs/node/blob/8cf5ae07e9e80747c19e0fc04fad48423707f62c/lib/_http_common.js#L222
+ */
+export const isHttpToken = (val) => TOKEN_REGEX.test(val);
+
+const HEADER_CHAR_REGEX = /[^\t\x20-\x7e\x80-\xff]/;
+
+/**
+ * True if val contains an invalid field-vchar
+ *  field-value    = *( field-content / obs-fold )
+ *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ * @see https://github.com/nodejs/node/blob/8cf5ae07e9e80747c19e0fc04fad48423707f62c/lib/_http_common.js#L233
+ */
+export const isInvalidHeaderChar = (val) => HEADER_CHAR_REGEX.test(val);
+
 // This code is based on Node.js' validateHeader() function from _http_outgoing.js module
 // (see https://github.com/nodejs/node/blob/189d29f39e6de9ccf10682bfd1341819b4a2291f/lib/_http_outgoing.js#L485)
 export const isInvalidHeader = (name, value) => {
     // NOTE: These are internal Node.js functions, they might stop working in the future!
     return typeof name !== 'string'
         || !name
-        || !_checkIsHttpToken(name)
+        || !isHttpToken(name)
         || value === undefined
-        || _checkInvalidHeaderChar(value);
+        || isInvalidHeaderChar(value);
 };
 
 const bulletproofDecodeURIComponent = (encodedURIComponent) => {

--- a/src/tools.js
+++ b/src/tools.js
@@ -47,7 +47,7 @@ const TOKEN_REGEX = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
  * @see https://tools.ietf.org/html/rfc7230#section-3.2.6
  * @see https://github.com/nodejs/node/blob/8cf5ae07e9e80747c19e0fc04fad48423707f62c/lib/_http_common.js#L222
  */
-export const isHttpToken = (val) => TOKEN_REGEX.test(val);
+const isHttpToken = (val) => TOKEN_REGEX.test(val);
 
 const HEADER_CHAR_REGEX = /[^\t\x20-\x7e\x80-\xff]/;
 
@@ -58,7 +58,7 @@ const HEADER_CHAR_REGEX = /[^\t\x20-\x7e\x80-\xff]/;
  *  field-vchar    = VCHAR / obs-text
  * @see https://github.com/nodejs/node/blob/8cf5ae07e9e80747c19e0fc04fad48423707f62c/lib/_http_common.js#L233
  */
-export const isInvalidHeaderChar = (val) => HEADER_CHAR_REGEX.test(val);
+const isInvalidHeaderChar = (val) => HEADER_CHAR_REGEX.test(val);
 
 // This code is based on Node.js' validateHeader() function from _http_outgoing.js module
 // (see https://github.com/nodejs/node/blob/189d29f39e6de9ccf10682bfd1341819b4a2291f/lib/_http_outgoing.js#L485)

--- a/test/tools.js
+++ b/test/tools.js
@@ -261,6 +261,7 @@ describe('tools.isInvalidHeader()', () => {
     it('works', () => {
         expect(isInvalidHeader('With space', 'a')).to.eql(true);
         expect(isInvalidHeader('', 'a')).to.eql(true);
+        expect(isInvalidHeader(undefined, 'a')).to.eql(true);
         expect(isInvalidHeader(null, 'a')).to.eql(true);
         expect(isInvalidHeader(1234, 'a')).to.eql(true);
         expect(isInvalidHeader('\n', 'a')).to.eql(true);


### PR DESCRIPTION
The checks is `isInvalidHeader` method are now backported from node's source.
Both methods were just a regexp checks, so it was trivial to use the very same
logic as in node.

The implementation changed a bit, `checkInvalidHeaderChar` is now implemented via regexp check,
and the `validateHeader` method was split into `validateHeaderName` and `validateHeaderValue`.

Both regexps are taken from the latest code from master. Also verified the exiting test in node,
but they seem to be aligned with the existing test suite (added only one additional assertion
for `undefined`).

Closes #50