### PR TITLE
Exposing the CONNECT response details of chained tunnels via a new event

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,32 @@ If it's `false`, the function will wait until all connections are closed, which 
 If the `callback` parameter is omitted, the function returns a promise.
 
 
+## Accessing the CONNECT response headers for proxy tunneling
+
+Some upstream proxy providers might include valuable debugging information in the CONNECT response
+headers when establishing the proxy tunnel, for they may not modify future data in the tunneled
+connection.
+
+The proxy server would emit a `tunnelConnectResponded` event for exposing such information, where
+the parameter types of the event callback are described in [Node.js's documentation][1]. Example:
+
+[1]: https://nodejs.org/api/http.html#http_event_connect
+
+```javascript
+server.on('tunnelConnectResponded', ({ response, socket, head }) => {
+    console.log(`CONNECT response headers received: ${response.headers}`);
+});
+```
+
+Alternatively a [helper function](##helper-functions) may be used:
+
+```javascript
+listenConnectAnonymizedProxy(anonymizedProxyUrl, ({ response, socket, head }) => {
+    console.log(`CONNECT response headers received: ${response.headers}`);
+});
+```
+
+
 ## Helper functions
 
 The package also provides several utility functions.
@@ -306,6 +332,12 @@ If it's `false`, the function will wait until all connections are closed, which 
 
 The function takes an optional callback that receives the result of the function.
 If the callback is not provided, the function returns a promise instead.
+
+### `listenConnectAnonymizedProxy(anonymizedProxyUrl, tunnelConnectRespondedCallback)`
+
+Allows to configure a callback on the anonymized proxy URL for the CONNECT response headers. See the
+above section [Accessing the CONNECT response headers for proxy tunneling](#accessing-the-connect-response-headers-for-proxy-tunneling)
+for details.
 
 ### `parseUrl(url)`
 

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -99,6 +99,6 @@ export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, onTrgRequestCon
         onTrgRequestConnectCallback(false);
     }
     server.on('onTrgRequestConnect', ({ response, socket, head }) => {
-        onTrgRequestConnectCallback(response,socket,head);
+        onTrgRequestConnectCallback({ response,socket,head });
     });
 };

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -86,3 +86,19 @@ export const closeAnonymizedProxy = (anonymizedProxyUrl, closeConnections, callb
         });
     return nodeify(promise, callback);
 };
+
+/**
+ * Add a callback on 'onTrgRequestConnect' Event in order to get headers from CONNECT tunnel to proxy
+ * Useful for some proxies that are using headers to send information like ProxyMesh
+ * @param anonymizedProxyUrl
+ * @param onTrgRequestConnectCallback
+ */
+export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, onTrgRequestConnectCallback) => {
+    const server = anonymizedProxyUrlToServer[anonymizedProxyUrl];
+    if (!server) {
+        onTrgRequestConnectCallback(false);
+    }
+    server.on('onTrgRequestConnect', ({ response, socket, head }) => {
+        onTrgRequestConnectCallback(response,socket,head);
+    });
+};

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -99,6 +99,6 @@ export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, tunnelConnectRe
         tunnelConnectRespondedCallback(false);
     }
     server.on('tunnelConnectResponded', ({ response, socket, head }) => {
-        tunnelConnectRespondedCallback({ response,socket,head });
+        tunnelConnectRespondedCallback({ response, socket, head });
     });
 };

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -88,17 +88,17 @@ export const closeAnonymizedProxy = (anonymizedProxyUrl, closeConnections, callb
 };
 
 /**
- * Add a callback on 'onTrgRequestConnect' Event in order to get headers from CONNECT tunnel to proxy
+ * Add a callback on 'tunnelConnectResponded' Event in order to get headers from CONNECT tunnel to proxy
  * Useful for some proxies that are using headers to send information like ProxyMesh
  * @param anonymizedProxyUrl
- * @param onTrgRequestConnectCallback
+ * @param tunnelConnectRespondedCallback
  */
-export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, onTrgRequestConnectCallback) => {
+export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, tunnelConnectRespondedCallback) => {
     const server = anonymizedProxyUrlToServer[anonymizedProxyUrl];
     if (!server) {
-        onTrgRequestConnectCallback(false);
+        tunnelConnectRespondedCallback(false);
     }
-    server.on('onTrgRequestConnect', ({ response, socket, head }) => {
-        onTrgRequestConnectCallback({ response,socket,head });
+    server.on('tunnelConnectResponded', ({ response, socket, head }) => {
+        tunnelConnectRespondedCallback({ response,socket,head });
     });
 };

--- a/src/anonymize_proxy.js
+++ b/src/anonymize_proxy.js
@@ -91,14 +91,19 @@ export const closeAnonymizedProxy = (anonymizedProxyUrl, closeConnections, callb
  * Add a callback on 'tunnelConnectResponded' Event in order to get headers from CONNECT tunnel to proxy
  * Useful for some proxies that are using headers to send information like ProxyMesh
  * @param anonymizedProxyUrl
- * @param tunnelConnectRespondedCallback
+ * @param tunnelConnectRespondedCallback Callback to be invoked upon receiving the response. It
+ * shall take an object as its parameter, with three keys `response`, `socket`, and `head` as
+ * described here: https://nodejs.org/api/http.html#http_event_connect
+ * @returns `true` if the callback is successfully configured, otherwise `false` (e.g. when an
+ * invalid proxy URL is given).
  */
 export const listenConnectAnonymizedProxy = (anonymizedProxyUrl, tunnelConnectRespondedCallback) => {
     const server = anonymizedProxyUrlToServer[anonymizedProxyUrl];
     if (!server) {
-        tunnelConnectRespondedCallback(false);
+        return false;
     }
     server.on('tunnelConnectResponded', ({ response, socket, head }) => {
         tunnelConnectRespondedCallback({ response, socket, head });
     });
+    return true;
 };

--- a/src/handler_tunnel_chain.js
+++ b/src/handler_tunnel_chain.js
@@ -58,7 +58,7 @@ export default class HandlerTunnelChain extends HandlerBase {
         this.srcResponse.removeListener('finish', this.onSrcResponseFinish);
         this.srcResponse.writeHead(200, 'Connection Established');
 
-        this.emit('onTrgRequestConnect', { response, socket, head });
+        this.emit('tunnelConnectResponded', { response, socket, head });
 
         // HACK: force a flush of the HTTP header. This is to ensure 'head' is empty to avoid
         // assert at https://github.com/request/tunnel-agent/blob/master/index.js#L160

--- a/src/handler_tunnel_chain.js
+++ b/src/handler_tunnel_chain.js
@@ -58,6 +58,8 @@ export default class HandlerTunnelChain extends HandlerBase {
         this.srcResponse.removeListener('finish', this.onSrcResponseFinish);
         this.srcResponse.writeHead(200, 'Connection Established');
 
+        this.emit('onTrgRequestConnect', { response, socket, head });
+
         // HACK: force a flush of the HTTP header. This is to ensure 'head' is empty to avoid
         // assert at https://github.com/request/tunnel-agent/blob/master/index.js#L160
         // See also https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L217

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Server, RequestError } from './server';
 import { parseUrl, redactUrl, redactParsedUrl } from './tools';
-import { anonymizeProxy, closeAnonymizedProxy } from './anonymize_proxy';
+import { anonymizeProxy, closeAnonymizedProxy, listenConnectAnonymizedProxy } from './anonymize_proxy';
 import { createTunnel, closeTunnel } from './tcp_tunnel_tools';
 
 // Publicly exported functions and classes
@@ -12,6 +12,7 @@ const ProxyChain = {
     redactParsedUrl,
     anonymizeProxy,
     closeAnonymizedProxy,
+    listenConnectAnonymizedProxy,
     createTunnel,
     closeTunnel,
 };

--- a/src/server.js
+++ b/src/server.js
@@ -354,6 +354,15 @@ export class Server extends EventEmitter {
             this.log(handler.id, '!!! Closed and removed from server');
         });
 
+        handler.once('onTrgRequestConnect', ({ response, socket, head }) => {
+            this.emit('onTrgRequestConnect', {
+                connectionId: handler.id,
+                response,
+                socket,
+                head,
+            });
+        });
+
         handler.run();
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -354,8 +354,8 @@ export class Server extends EventEmitter {
             this.log(handler.id, '!!! Closed and removed from server');
         });
 
-        handler.once('onTrgRequestConnect', ({ response, socket, head }) => {
-            this.emit('onTrgRequestConnect', {
+        handler.once('tunnelConnectResponded', ({ response, socket, head }) => {
+            this.emit('tunnelConnectResponded', {
                 connectionId: handler.id,
                 response,
                 socket,


### PR DESCRIPTION
This is considered useful when some proxy providers may include useful information (e.g. for debugging) in the CONNECT response headers.

Implements #30.

This PR is based on the earlier commit in #31 (thanks @Benraay!) with these additional changes:
- Resolved conflicts between the earlier commit and the current `master` branch.
- Added a new test case for this very feature
- Slightly adjusted the callback interface in `listenConnectAnonymizedProxy`
- Renamed the event name (`onTrgRequestConnect` -> `tunnelConnectResponded`) for this may be accessed by users directly (via `server.on`).