### PR TITLE
parseUrl: return standard ports for http(s) when port is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.1 / 2021-04-09
+==================
+ - Bugfix: `parseUrl()` result now always includes port for `http(s)`, `ftp` and `ws(s)` (even if explicitly specified port is the default one)
+   This fixes [#123](https://github.com/apify/proxy-chain/issues/123).
+
 1.0.0 / 2021-03-17
 ===================
 - **BREAKING:** The `parseUrl()` function slightly changed its behavior (see README for details):

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ It parses the URL using Node.js' `new URL(url)` and adds the following features:
   (if not, the function keeps the username and password as is)
 - `auth` field is added, and it contains username + ":" + password, or an empty string.
 
+Note that `port` is returned even if it is a default port for `http(s)` and few other protocols. This differs from `new URL(url)` where port is null when default.
+
 If the URL is invalid, the function throws an error.
 
 The username and password parsing should make it possible to parse proxy URLs containing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "build/index.js",
   "keywords": [

--- a/src/tools.js
+++ b/src/tools.js
@@ -80,9 +80,13 @@ const bulletproofDecodeURIComponent = (encodedURIComponent) => {
 };
 
 // Ports returned by `parseUrl` when port is not explicitly specified.
+// Values are based on node docs: https://nodejs.org/api/url.html#url_url_port
 const STANDARD_PORTS_BY_PROTOCOL = {
+    'ftp:': 21,
     'http:': 80,
     'https:': 443,
+    'ws:': 80,
+    'wss:': 443,
 };
 
 /**

--- a/src/tools.js
+++ b/src/tools.js
@@ -79,6 +79,12 @@ const bulletproofDecodeURIComponent = (encodedURIComponent) => {
     }
 };
 
+// Ports returned by `parseUrl` when port is not explicitly specified.
+const STANDARD_PORTS_BY_PROTOCOL = {
+    'http:': 80,
+    'https:': 443,
+};
+
 /**
  * Parses a URL using Node.js' `new URL(url)` and adds the following features:
  *  - `port` is casted to number / null from string
@@ -126,6 +132,11 @@ export const parseUrl = (url) => {
         if (matches && matches.length === 2) {
             parsed.scheme = matches[1];
         }
+    }
+
+    // Add default port based on protocol when no port is explicitly specified.
+    if (parsed.port === null) {
+        parsed.port = STANDARD_PORTS_BY_PROTOCOL[parsed.protocol] || null;
     }
 
     return parsed;

--- a/test/anonymize_proxy.js
+++ b/test/anonymize_proxy.js
@@ -119,9 +119,7 @@ describe('utils.anonymizeProxy', function () {
     it('throws for invalid URLs', () => {
         assert.throws(() => { anonymizeProxy('://whatever.com'); }, Error);
         assert.throws(() => { anonymizeProxy('https://whatever.com'); }, Error);
-        assert.throws(() => { anonymizeProxy('http://no-port-specified'); }, Error);
         assert.throws(() => { anonymizeProxy('socks5://whatever.com'); }, Error);
-        assert.throws(() => { anonymizeProxy('http://no-port-provided'); }, Error);
     });
 
     it('keeps already anonymous proxies (both with callbacks and promises)', () => {

--- a/test/tcp_tunnel.js
+++ b/test/tcp_tunnel.js
@@ -56,7 +56,6 @@ describe('tcp_tunnel.createTunnel', () => {
     it('throws error if proxyUrl is not in correct format', () => {
         assert.throws(() => { createTunnel('socks://user:password@whatever.com:123', 'localhost:9000'); }, /must have the "http" protocol/);
         assert.throws(() => { createTunnel('socks5://user:password@whatever.com', 'localhost:9000'); }, /must contain hostname and port/);
-        assert.throws(() => { createTunnel('http://user:password@whatever.com', 'localhost:9000'); }, /must contain hostname and port/);
         assert.throws(() => { createTunnel('http://us%3Aer:password@whatever.com:345', 'localhost:9000'); }, /cannot contain the colon/);
     });
     it('throws error if target is not in correct format', () => {

--- a/test/tools.js
+++ b/test/tools.js
@@ -59,7 +59,7 @@ describe('tools.parseUrl()', () => {
             password: 'password',
             host: 'www.example.com',
             hostname: 'www.example.com',
-            port: null,
+            port: 443,
             path: '/some/path',
         });
 
@@ -136,7 +136,7 @@ describe('tools.parseUrl()', () => {
             scheme: 'http',
             username: '',
             password: '',
-            port: null,
+            port: 80,
         });
 
         testUrl('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/', {
@@ -145,7 +145,7 @@ describe('tools.parseUrl()', () => {
             username: '',
             password: '',
             hostname: '[2001:db8:85a3:8d3:1319:8a2e:370:7348]',
-            port: null,
+            port: 80,
         });
 
         testUrl('http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/', {
@@ -177,6 +177,15 @@ describe('tools.parseUrl()', () => {
             port: 12345,
             path: '/',
         });
+
+        // Test that default ports are added for http and https
+        testUrl('https://www.example.com', { port: 443 });
+        testUrl('http://www.example.com', { port: 80 });
+        // Test that default port is not added for other protocols
+        testUrl('ftp://www.example.com', { port: null });
+        // Test that explicit port is returned when specified
+        testUrl('https://www.example.com:12345', { port: 12345 });
+        testUrl('http://www.example.com:12345', { port: 12345 });
 
         expect(() => {
             parseUrl('/some-relative-url?a=1');

--- a/test/tools.js
+++ b/test/tools.js
@@ -185,7 +185,8 @@ describe('tools.parseUrl()', () => {
         testUrl('wss://www.example.com', { port: 443 });
         testUrl('ws://www.example.com', { port: 80 });
         // Test that default port is not added for other protocols
-        testUrl('sock5://www.example.com', { port: null });
+        testUrl('socks5://www.example.com', { port: null });
+        testUrl('socks5://www.example.com:1080', { port: 1080 });
         // Test that explicit port is returned when specified
         testUrl('https://www.example.com:12345', { port: 12345 });
         testUrl('http://www.example.com:12345', { port: 12345 });

--- a/test/tools.js
+++ b/test/tools.js
@@ -181,8 +181,11 @@ describe('tools.parseUrl()', () => {
         // Test that default ports are added for http and https
         testUrl('https://www.example.com', { port: 443 });
         testUrl('http://www.example.com', { port: 80 });
+        // ... and for web sockets
+        testUrl('wss://www.example.com', { port: 443 });
+        testUrl('ws://www.example.com', { port: 80 });
         // Test that default port is not added for other protocols
-        testUrl('ftp://www.example.com', { port: null });
+        testUrl('sock5://www.example.com', { port: null });
         // Test that explicit port is returned when specified
         testUrl('https://www.example.com:12345', { port: 12345 });
         testUrl('http://www.example.com:12345', { port: 12345 });


### PR DESCRIPTION
Proxy url returns standard ports for few protocols (see https://nodejs.org/api/url.html#url_url_port) when no port is explicitly specified.

Removed tests which needlesly require the standard port
 - in `createTunnel`, only the parsed url is used in the end, so it should be ok
 - in `anonymizeProxy`, the raw (unparsed) url is passed to `Server` through `prepareRequestFunction`. There it also uses only the parsed version.

Resolves #123 