### PR TITLE
fix EventEmitter memory leak

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -211,6 +211,7 @@ export class Server extends EventEmitter {
         // See https://github.com/apify/proxy-chain/issues/53
         // TODO: HandlerBase will also attach its own 'error' handler, we should only attach this one
         //  if HandlerBase doesn't do it, to avoid duplicate logs
+        socket.removeAllListeners('error'); // remove all listeners to prevent memory leak
         socket.on('error', (err) => {
             this.log(handlerOpts.id, `Source socket emitted error: ${err.stack || err}`);
         });


### PR DESCRIPTION
When the listener is running I get this error every second: `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit`

When I launched my app with `node --trace-warnings app.js` it showed that the stack trace is at line 284 in server.js. The server registers the error listener repeatedly so I added a small hack to remove every error listener before adding a new one.

There might be better ways to solve this but this is a solution for now.