### PR TITLE
fix: convert connectionId symbol to string

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -159,11 +159,7 @@ export class Server extends EventEmitter {
 
     log(connectionId: unknown, str: string): void {
         if (this.verbose) {
-            if (typeof connectionId === 'symbol') {
-                connectionId = connectionId.toString();
-            }
-
-            const logPrefix = connectionId ? `${connectionId} | ` : '';
+            const logPrefix = connectionId ? `${String(connectionId)} | ` : '';
             console.log(`ProxyServer[${this.port}]: ${logPrefix}${str}`);
         }
     }


### PR DESCRIPTION
I'm not sure if it's something I'm doing, but trying to use the 2.0.0 beta (tried 0 and 2) yields this error on trying to start the chain:

```
Cannot convert a Symbol value to a string
TypeError: Cannot convert a Symbol value to a string
    at Server.log (node_modules/proxy-chain/src/server.ts:162:49)
    at Server.failRequest (node_modules/proxy-chain/src/server.ts:450:18)
    at Server.onConnect (node_modules/proxy-chain/src/server.ts:281:18)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Searching around it does seem to be the case that `Symbol` doesn't automatically convert to string?

With this erroring out this way, it seems like it breaks out of proxy chain initialization, attempting to connect to it just hangs/times out eventually (notably different from outright connection refused).

This change fixes it.

Not sure if this is how you'd like to handle it, or if you'd rather more broadly see if the object has a `toString()` function and if so call it.