### PR TITLE
feat: allow closing connections

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -565,6 +565,21 @@ export class Server extends EventEmitter {
     }
 
     /**
+     * Forcibly closes pending proxy connections.
+     */
+    closeConnections(): void {
+        this.log(null, 'Closing pending sockets');
+
+        for (const socket of this.connections.values()) {
+            socket.destroy();
+        }
+
+        this.connections.clear();
+
+        this.log(null, `Destroyed ${this.connections.size} pending sockets`);
+    }
+
+    /**
      * Closes the proxy server.
      * @param closeConnections If true, pending proxy connections are forcibly closed.
      */
@@ -575,15 +590,7 @@ export class Server extends EventEmitter {
         }
 
         if (closeConnections) {
-            this.log(null, 'Closing pending sockets');
-
-            for (const socket of this.connections.values()) {
-                socket.destroy();
-            }
-
-            this.connections.clear();
-
-            this.log(null, `Destroyed ${this.connections.size} pending sockets`);
+            this.closeConnections();
         }
 
         if (this.server) {


### PR DESCRIPTION
Expose the connection-closing code as a public method.

This can be useful to do some times and probably preferable to completely destroying the proxy-chain and recreating it.

---

The particular scenario I'm running into is between Chrome headless browser (puppeteer) and proxy-chain. When connecting to HTTPS sites via HTTP CONNECT, puppeteer opens the sockets with a keep-alive.

I define my own `prepareRequestFunction` which dynamically selects the `upstreamProxyUrl`. I have code that can basically on-demand change what `upstreamProxyUrl` is returned by my `prepareRequestFunction`.

Once the HTTP CONNECT tunnel is established, `prepareRequestFunction` no longer factors in: that socket is forever tied to that `upstreamProxyUrl` (correct me if I'm wrong).

I have some code that changes the `upstreamProxyUrl` returned by `prepareRequestFunction`. It works fine for HTTP targets.

However, for HTTPS, if an entirely _new_ request is made in Puppeteer, Chrome reuses the prior tunnel socket that was kept alive, thereby not taking on the effect of the changed `upstreamProxyUrl`.

The way I thought to fix this was to basically close all pending connections whenever the `upstreamProxyUrl` was changed on my end. This theoretically may appear disruptive as potentially-ongoing requests would be interrupted, but in practice I think things operate serially so for the most part this shouldn't occur.

Currently this could be accomplished by entirely destroying and recreating the proxy chain, but that seemed excessive when we could simply expose the method that closes pending connections.

Perhaps a more targeted approach would be to track which sockets/connections are tied to HTTP CONNECT tunnels, and expose some `closeTunnels()`-type method? But then again maybe this situation could also apply to HTTP depending on if Chrome reuses the connections (I don't think it does but I'm not too well versed on those low-level details).

Either way, I think exposing this `closeConnections()` method would be useful to users, but I'm curious if anyone has thoughts on this situation.