### PR TITLE
Pass proxyChainId to tunnelConnectResponded

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ the parameter types of the event callback are described in [Node.js's documentat
 [1]: https://nodejs.org/api/http.html#http_event_connect
 
 ```javascript
-server.on('tunnelConnectResponded', ({ response, socket, head }) => {
+server.on('tunnelConnectResponded', ({ proxyChainId, response, socket, head }) => {
     console.log(`CONNECT response headers received: ${response.headers}`);
 });
 ```

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -118,6 +118,7 @@ export const chain = (
         }
 
         server.emit('tunnelConnectResponded', {
+            proxyChainId,
             response,
             socket: targetSocket,
             head: clientHead,


### PR DESCRIPTION
Would be useful to also pass the proxyChainId, for logging/tracking purposes on each connection.