### PR TITLE
feat: family option

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -23,12 +23,14 @@ interface Options {
     headers: string[];
     path?: string;
     localAddress?: string;
+    family?: number;
     lookup?: typeof dns['lookup'];
 }
 
 export interface HandlerOpts {
     upstreamProxyUrlParsed: URL;
     localAddress?: string;
+    ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
 }
 
@@ -74,6 +76,7 @@ export const chain = (
             request.url!,
         ],
         localAddress: handlerOpts.localAddress,
+        family: handlerOpts.ipFamily,
         lookup: handlerOpts.dnsLookup,
     };
 

--- a/src/direct.ts
+++ b/src/direct.ts
@@ -8,6 +8,7 @@ import { Socket } from './socket';
 
 export interface HandlerOpts {
     localAddress?: string;
+    ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
 }
 
@@ -51,6 +52,7 @@ export const direct = (
         port: Number(url.port),
         host: url.hostname,
         localAddress: handlerOpts.localAddress,
+        family: handlerOpts.ipFamily,
         lookup: handlerOpts.dnsLookup,
     };
 

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -16,12 +16,14 @@ interface Options {
     insecureHTTPParser: boolean;
     path?: string;
     localAddress?: string;
+    family?: number;
     lookup?: typeof dns['lookup'];
 }
 
 export interface HandlerOpts {
     upstreamProxyUrlParsed: URL;
     localAddress?: string;
+    ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
 }
 
@@ -56,6 +58,7 @@ export const forward = async (
         headers: validHeadersOnly(request.rawHeaders),
         insecureHTTPParser: true,
         localAddress: handlerOpts.localAddress,
+        family: handlerOpts.ipFamily,
         lookup: handlerOpts.dnsLookup,
     };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@ type HandlerOpts = {
     isHttp: boolean;
     customResponseFunction: CustomResponseOpts['customResponseFunction'] | null;
     localAddress?: string;
+    ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
 };
 
@@ -66,6 +67,7 @@ export type PrepareRequestFunctionResult = {
     failMsg?: string;
     upstreamProxyUrl?: string | null;
     localAddress?: string;
+    ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
 };
 
@@ -400,6 +402,7 @@ export class Server extends EventEmitter {
         const funcResult = await this.callPrepareRequestFunction(request, handlerOpts);
 
         handlerOpts.localAddress = funcResult.localAddress;
+        handlerOpts.ipFamily = funcResult.ipFamily;
         handlerOpts.dnsLookup = funcResult.dnsLookup;
 
         // If not authenticated, request client to authenticate


### PR DESCRIPTION
family option is needed in order to use ipv6 as localAddress or upstream, since otherwise dns.lookup only returns one ipv4 address. #219 