### PR TITLE
chore: remove unused properties

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -39,8 +39,6 @@ interface ChainOpts {
     handlerOpts: HandlerOpts;
     server: EventEmitter & { log: (...args: any[]) => void; };
     isPlain: boolean;
-    localAddress?: string;
-    dnsLookup?: typeof dns['lookup'];
 }
 
 /**


### PR DESCRIPTION
The following properties have probably been set by mistake and arent needed there.