### PR TITLE
docs: Fix example for anonymizeProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ const proxyChain = require('proxy-chain');
 
 (async() => {
     const oldProxyUrl = 'http://bob:password123@proxy.example.com:8000';
-    const newProxyUrl = await proxyChain.anonymizeProxy({ url: oldProxyUrl });
+    const newProxyUrl = await proxyChain.anonymizeProxy(oldProxyUrl);
 
     // Prints something like "http://127.0.0.1:45678"
     console.log(newProxyUrl);


### PR DESCRIPTION
The previous example doesn't set the port and the code fallback to the DEFAULT_PROXY_SERVER_PORT no random port in this configuration.

Another patch is possible `port: 0` but is less explicit.

```
const newProxyUrl = await proxyChain.anonymizeProxy({ url: oldProxyUrl, port: 0 });
```