### PR TITLE
feat: custom connect http server

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@apify/eslint-config-ts": "^0.2.3",
     "@apify/tsconfig": "^0.1.0",
     "@types/jest": "^28.1.2",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.8.3",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
     "basic-auth": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -12,7 +12,7 @@ export const customConnect = async (socket: net.Socket, server: http.Server): Pr
     server.emit('connection', socket);
 
     return new Promise((resolve) => {
-        if (socket.closed) {
+        if (socket.destroyed) {
             resolve();
             return;
         }

--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -1,0 +1,24 @@
+import net from 'net';
+import type http from 'http';
+import { promisify } from 'util';
+// import { countTargetBytes } from './utils/count_target_bytes';
+
+const asyncWrite = promisify(net.Socket.prototype.write);
+
+export const customConnect = async (socket: net.Socket, server: http.Server): Promise<void> => {
+    // countTargetBytes(socket, socket);
+
+    await asyncWrite.call(socket, 'HTTP/1.1 200 Connection Established\r\n\r\n');
+    server.emit('connection', socket);
+
+    return new Promise((resolve) => {
+        if (socket.closed) {
+            resolve();
+            return;
+        }
+
+        socket.once('close', () => {
+            resolve();
+        });
+    });
+};

--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -1,12 +1,15 @@
 import net from 'net';
 import type http from 'http';
 import { promisify } from 'util';
-// import { countTargetBytes } from './utils/count_target_bytes';
 
 const asyncWrite = promisify(net.Socket.prototype.write);
 
 export const customConnect = async (socket: net.Socket, server: http.Server): Promise<void> => {
-    // countTargetBytes(socket, socket);
+    // `countTargetBytes(socket, socket)` is incorrect here since `socket` is not a target.
+    // We would have to create a new stream and pipe traffic through that,
+    // however this would also increase CPU usage.
+    // Also, counting bytes here is not correct since we don't know how the response is generated
+    // (whether any additional sockets are used).
 
     await asyncWrite.call(socket, 'HTTP/1.1 200 Connection Established\r\n\r\n');
     server.emit('connection', socket);


### PR DESCRIPTION
This would enable to use CONNECT for SERP requests. Currently using [`hpagent`](https://github.com/delvedor/hpagent) doesn't work when doing SERPs, because it only supports CONNECT proxying.

/cc @AndreyBykov 