### PR TITLE
fix: Handle socket timeout to prevent connections from leaking

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -203,6 +203,11 @@ export class Server extends EventEmitter {
 
             this.connections.delete(unique);
         });
+        // We have to manually destroy the socket if it timeouts.
+        // This will prevent connections from leaking and close them properly.
+        socket.on('timeout', () => {
+            socket.destroy();
+        });
     }
 
     /**


### PR DESCRIPTION
https://nodejs.org/api/net.html#event-timeout `Emitted if the socket times out from inactivity. This is only to notify that the socket has been idle. The user must manually close the connection.`