### PR TITLE
feat: Add `metadata` parameter to the tunnelConnectResponded event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -33,6 +33,7 @@ export interface HandlerOpts {
     localAddress?: string;
     ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
+    metadata?: Record<string, unknown>;
 }
 
 interface ChainOpts {
@@ -72,7 +73,7 @@ export const chain = (
 
     const { proxyChainId } = sourceSocket;
 
-    const { upstreamProxyUrlParsed: proxy } = handlerOpts;
+    const { upstreamProxyUrlParsed: proxy, metadata } = handlerOpts;
 
     const options: Options = {
         method: 'CONNECT',
@@ -127,6 +128,14 @@ export const chain = (
                 sourceSocket.end(createHttpResponse(status, `UPSTREAM${response.statusCode}`));
             }
 
+            server.emit('tunnelConnectError', {
+                proxyChainId,
+                response,
+                metadata,
+                socket: targetSocket,
+                head: clientHead,
+            });
+
             return;
         }
 
@@ -138,6 +147,7 @@ export const chain = (
         server.emit('tunnelConnectResponded', {
             proxyChainId,
             response,
+            metadata,
             socket: targetSocket,
             head: clientHead,
         });

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ type HandlerOpts = {
     localAddress?: string;
     ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
+    metadata?: Record<string, unknown>;
 };
 
 export type PrepareRequestFunctionOpts = {
@@ -73,6 +74,7 @@ export type PrepareRequestFunctionResult = {
     localAddress?: string;
     ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
+    metadata?: Record<string, unknown>;
 };
 
 type Promisable<T> = T | Promise<T>;
@@ -419,6 +421,7 @@ export class Server extends EventEmitter {
         handlerOpts.ipFamily = funcResult.ipFamily;
         handlerOpts.dnsLookup = funcResult.dnsLookup;
         handlerOpts.customConnectServer = funcResult.customConnectServer;
+        handlerOpts.metadata = funcResult.metadata;
 
         // If not authenticated, request client to authenticate
         if (funcResult.requestAuthentication) {


### PR DESCRIPTION
Also add tunnelConnectError event.

This is used to pass information that was passed by `prepareRequestFunction` back via events