### PR TITLE
refactor: Avoid accessing prototype in custom_connect

### DIFF
--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -10,7 +10,7 @@ export const customConnect = async (socket: net.Socket, server: http.Server): Pr
     // (whether any additional sockets are used).
 
     const asyncWrite = promisify(socket.write).bind(socket);
-    await asyncWrite.call(socket, 'HTTP/1.1 200 Connection Established\r\n\r\n');
+    await asyncWrite('HTTP/1.1 200 Connection Established\r\n\r\n');
     server.emit('connection', socket);
 
     return new Promise((resolve) => {

--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -2,7 +2,8 @@ import net from 'net';
 import type http from 'http';
 import { promisify } from 'util';
 
-const asyncWrite = promisify(net.Socket.prototype.write);
+const socket = new net.Socket();
+const asyncWrite = promisify(socket.write).bind(socket);
 
 export const customConnect = async (socket: net.Socket, server: http.Server): Promise<void> => {
     // `countTargetBytes(socket, socket)` is incorrect here since `socket` is not a target.

--- a/src/custom_connect.ts
+++ b/src/custom_connect.ts
@@ -2,9 +2,6 @@ import net from 'net';
 import type http from 'http';
 import { promisify } from 'util';
 
-const socket = new net.Socket();
-const asyncWrite = promisify(socket.write).bind(socket);
-
 export const customConnect = async (socket: net.Socket, server: http.Server): Promise<void> => {
     // `countTargetBytes(socket, socket)` is incorrect here since `socket` is not a target.
     // We would have to create a new stream and pipe traffic through that,
@@ -12,6 +9,7 @@ export const customConnect = async (socket: net.Socket, server: http.Server): Pr
     // Also, counting bytes here is not correct since we don't know how the response is generated
     // (whether any additional sockets are used).
 
+    const asyncWrite = promisify(socket.write).bind(socket);
     await asyncWrite.call(socket, 'HTTP/1.1 200 Connection Established\r\n\r\n');
     server.emit('connection', socket);
 


### PR DESCRIPTION
See the discussion here: https://github.com/apify/proxy-chain/issues/521#issuecomment-1685378805

NOTE: I tried running `npm run test` to ensure everything works. But the tests were failing because of other error (below) even before I made the change, so I can't ensure integrity.

```sh
$ npm run test

> proxy-chain@2.3.0 test
> nyc cross-env NODE_OPTIONS=--insecure-http-parser mocha --bail



(node:23123) Warning: Using insecure HTTP parsing
(Use `node --trace-warnings ...` to show where the warning was created)
  1) supports localAddress

  0 passing (2s)
  1 failing

  1) supports localAddress:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/presenter/repos/proxy-chain/test/server.js)
      at listOnTimeout (node:internal/timers:557:17)
      at processTimers (node:internal/timers:500:7)
```