### PR TITLE
feat: Add option to specify server's `host`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ const server = new ProxyChain.Server({
     // Port where the server will listen. By default 8000.
     port: 8000,
 
+    // Hostname where the server will listen.
+    // optional, defaults to unspecified IP address, see e.g. https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
+    hostname: 'localhost',
+
     // Enables verbose logging
     verbose: true,
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ const server = new ProxyChain.Server({
     // Port where the server will listen. By default 8000.
     port: 8000,
 
-    // Hostname where the server will listen.
-    // optional, defaults to unspecified IP address, see e.g. https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
-    hostname: 'localhost',
+    // Optional host where the proxy server will listen.
+    // If not specified, the sever listens on an unspecified IP address (0.0.0.0 in IPv4, :: in IPv6)
+    // You can use this option to limit the access to the proxy server.
+    host: 'localhost',
 
     // Enables verbose logging
     verbose: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/src/anonymize_proxy.ts
+++ b/src/anonymize_proxy.ts
@@ -56,7 +56,7 @@ export const anonymizeProxy = (
             server = new Server({
                 // verbose: true,
                 port,
-                host: 'localhost',
+                host: '127.0.0.1',
                 prepareRequestFunction: () => {
                     return {
                         requestAuthentication: false,

--- a/src/anonymize_proxy.ts
+++ b/src/anonymize_proxy.ts
@@ -56,6 +56,7 @@ export const anonymizeProxy = (
             server = new Server({
                 // verbose: true,
                 port,
+                host: 'localhost',
                 prepareRequestFunction: () => {
                     return {
                         requestAuthentication: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,8 @@ export type PrepareRequestFunction = (opts: PrepareRequestFunctionOpts) => Promi
 export class Server extends EventEmitter {
     port: number;
 
+    hostname?: string;
+
     prepareRequestFunction?: PrepareRequestFunction;
 
     authRealm: unknown;
@@ -138,6 +140,7 @@ export class Server extends EventEmitter {
      */
     constructor(options: {
         port?: number,
+        hostname?: string,
         prepareRequestFunction?: PrepareRequestFunction,
         verbose?: boolean,
         authRealm?: unknown,
@@ -150,6 +153,7 @@ export class Server extends EventEmitter {
             this.port = options.port;
         }
 
+        this.hostname = options.hostname;
         this.prepareRequestFunction = options.prepareRequestFunction;
         this.authRealm = options.authRealm || DEFAULT_AUTH_REALM;
         this.verbose = !!options.verbose;
@@ -537,8 +541,6 @@ export class Server extends EventEmitter {
 
     /**
      * Starts listening at a port specified in the constructor.
-     * @param callback Optional callback
-     * @return {(Promise|undefined)}
      */
     listen(callback?: (error: NodeJS.ErrnoException | null) => void): Promise<void> {
         const promise = new Promise<void>((resolve, reject) => {
@@ -562,7 +564,7 @@ export class Server extends EventEmitter {
 
             this.server.on('error', onError);
             this.server.on('listening', onListening);
-            this.server.listen(this.port);
+            this.server.listen(this.port, this.hostname);
         });
 
         return nodeify(promise, callback);

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,7 +88,7 @@ export type PrepareRequestFunction = (opts: PrepareRequestFunctionOpts) => Promi
 export class Server extends EventEmitter {
     port: number;
 
-    hostname?: string;
+    host?: string;
 
     prepareRequestFunction?: PrepareRequestFunction;
 
@@ -140,7 +140,7 @@ export class Server extends EventEmitter {
      */
     constructor(options: {
         port?: number,
-        hostname?: string,
+        host?: string,
         prepareRequestFunction?: PrepareRequestFunction,
         verbose?: boolean,
         authRealm?: unknown,
@@ -153,7 +153,7 @@ export class Server extends EventEmitter {
             this.port = options.port;
         }
 
-        this.hostname = options.hostname;
+        this.host = options.host;
         this.prepareRequestFunction = options.prepareRequestFunction;
         this.authRealm = options.authRealm || DEFAULT_AUTH_REALM;
         this.verbose = !!options.verbose;
@@ -564,7 +564,7 @@ export class Server extends EventEmitter {
 
             this.server.on('error', onError);
             this.server.on('listening', onListening);
-            this.server.listen(this.port, this.hostname);
+            this.server.listen(this.port, this.host);
         });
 
         return nodeify(promise, callback);


### PR DESCRIPTION
I've added support for specifying `host` used for the `listen` call. This will enable users to e.g. listen on `localhost`, which can be more secure than the default unspecified IP address (0.0.0.0).