### PR TITLE
Use key/value object in place of Array for requests headers

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -21,7 +21,7 @@ const createHttpResponse = (statusCode: number, statusMessage: string, message =
 
 interface Options {
     method: string;
-    headers: string[];
+    headers: Record<string, string>;
     path?: string;
     localAddress?: string;
     family?: number;
@@ -78,20 +78,19 @@ export const chain = (
     const options: Options = {
         method: 'CONNECT',
         path: request.url,
-        headers: [
-            'host',
-            request.url!,
-        ],
+        headers: {
+            host: request.url!,
+        },
         localAddress: handlerOpts.localAddress,
         family: handlerOpts.ipFamily,
         lookup: handlerOpts.dnsLookup,
     };
 
     if (proxy.username || proxy.password) {
-        options.headers.push('proxy-authorization', getBasicAuthorizationHeader(proxy));
+        options.headers['proxy-authorization'] = getBasicAuthorizationHeader(proxy);
     }
 
-    const client = http.request(proxy.origin, options as unknown as http.ClientRequestArgs);
+    const client = http.request(proxy.origin, options);
 
     client.on('connect', (response, targetSocket, clientHead) => {
         countTargetBytes(sourceSocket, targetSocket);

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -21,7 +21,7 @@ const createHttpResponse = (statusCode: number, statusMessage: string, message =
 
 interface Options {
     method: string;
-    headers: Record<string, string>;
+    headers: http.OutgoingHttpHeaders;
     path?: string;
     localAddress?: string;
     family?: number;

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -13,7 +13,7 @@ const pipeline = util.promisify(stream.pipeline);
 
 interface Options {
     method: string;
-    headers: string[];
+    headers: Record<string, string>;
     insecureHTTPParser: boolean;
     path?: string;
     localAddress?: string;
@@ -69,7 +69,7 @@ export const forward = async (
 
         try {
             if (proxy.username || proxy.password) {
-                options.headers.push('proxy-authorization', getBasicAuthorizationHeader(proxy));
+                options.headers['proxy-authorization'] = getBasicAuthorizationHeader(proxy);
             }
         } catch (error) {
             reject(error);
@@ -79,8 +79,7 @@ export const forward = async (
 
     const fn = origin!.startsWith('https:') ? https.request : http.request;
 
-    // We have to force cast `options` because @types/node doesn't support an array.
-    const client = fn(origin!, options as unknown as http.ClientRequestArgs, async (clientResponse) => {
+    const client = fn(origin!, options, async (clientResponse) => {
         try {
             // This is necessary to prevent Node.js throwing an error
             let statusCode = clientResponse.statusCode!;

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -13,7 +13,7 @@ const pipeline = util.promisify(stream.pipeline);
 
 interface Options {
     method: string;
-    headers: Record<string, string>;
+    headers: http.OutgoingHttpHeaders;
     insecureHTTPParser: boolean;
     path?: string;
     localAddress?: string;

--- a/src/utils/valid_headers_only.ts
+++ b/src/utils/valid_headers_only.ts
@@ -4,8 +4,8 @@ import { isHopByHopHeader } from './is_hop_by_hop_header';
 /**
  * @see https://nodejs.org/api/http.html#http_message_rawheaders
  */
-export const validHeadersOnly = (rawHeaders: string[]): string[] => {
-    const result = [];
+export const validHeadersOnly = (rawHeaders: string[]): Record<string, string> => {
+    const result: Record<string, string> = {};
 
     let containsHost = false;
 
@@ -35,7 +35,7 @@ export const validHeadersOnly = (rawHeaders: string[]): string[] => {
             containsHost = true;
         }
 
-        result.push(name, value);
+        result[name] = value;
     }
 
     return result;

--- a/src/utils/valid_headers_only.ts
+++ b/src/utils/valid_headers_only.ts
@@ -4,8 +4,8 @@ import { isHopByHopHeader } from './is_hop_by_hop_header';
 /**
  * @see https://nodejs.org/api/http.html#http_message_rawheaders
  */
-export const validHeadersOnly = (rawHeaders: string[]): Record<string, string> => {
-    const result: Record<string, string> = {};
+export const validHeadersOnly = (rawHeaders: string[]): Record<string, string[]> => {
+    const result: Record<string, string[]> = {};
 
     let containsHost = false;
 
@@ -35,7 +35,11 @@ export const validHeadersOnly = (rawHeaders: string[]): Record<string, string> =
             containsHost = true;
         }
 
-        result[name] = value;
+        if (result[name]) {
+            result[name].push(value);
+        } else {
+            result[name] = [value];
+        }
     }
 
     return result;


### PR DESCRIPTION
I came across an issue where the `anonymizeProxy` helper  function was not working correctly, and upstream proxy was returning 407, even if the username/password was correctly set in the proxy url.

I found out that the upstream proxy was not receiving the credential header correctly. `http` and `https` request should contain header according to [the API](https://nodejs.org/docs/latest-v14.x/api/http.html#http_http_request_options_callback).

With the proposed changes, the `anonymizeProxy` works correctly, and I no longer have errors