### PR TITLE
fix: decode username and password for socks tunnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/src/chain_socks.ts
+++ b/src/chain_socks.ts
@@ -50,8 +50,8 @@ export const chainSocks = async ({
         host: hostname,
         port: Number(port),
         type: socksProtocolToVersionNumber(handlerOpts.upstreamProxyUrlParsed.protocol),
-        userId: username,
-        password,
+        userId: decodeURIComponent(username),
+        password: decodeURIComponent(password),
     };
 
     if (head && head.length > 0) {

--- a/test/socks.js
+++ b/test/socks.js
@@ -51,14 +51,14 @@ describe('SOCKS protocol', () => {
             });
             socksServer.listen(socksPort, 'localhost');
             socksServer.useAuth(socksv5.auth.UserPassword((user, password, cb) => {
-                cb(user === 'proxy-chain' && password === 'rules!');
+                cb(user === 'proxy-ch@in' && password === 'rules!');
             }));
 
             proxyServer = new ProxyChain.Server({
                 port: proxyPort,
                 prepareRequestFunction() {
                     return {
-                        upstreamProxyUrl: `socks://proxy-chain:rules!@localhost:${socksPort}`,
+                        upstreamProxyUrl: `socks://proxy-ch@in:rules!@localhost:${socksPort}`,
                     };
                 },
             });
@@ -81,10 +81,10 @@ describe('SOCKS protocol', () => {
             });
             socksServer.listen(socksPort, 'localhost');
             socksServer.useAuth(socksv5.auth.UserPassword((user, password, cb) => {
-                cb(user === 'proxy-chain' && password === 'rules!');
+                cb(user === 'proxy-ch@in' && password === 'rules!');
             }));
 
-            ProxyChain.anonymizeProxy({ port: proxyPort, url: `socks://proxy-chain:rules!@localhost:${socksPort}` }).then((anonymizedProxyUrl) => {
+            ProxyChain.anonymizeProxy({ port: proxyPort, url: `socks://proxy-ch@in:rules!@localhost:${socksPort}` }).then((anonymizedProxyUrl) => {
                 anonymizeProxyUrl = anonymizedProxyUrl;
                 gotScraping.get({ url: 'https://example.com', proxyUrl: anonymizedProxyUrl })
                     .then((response) => {


### PR DESCRIPTION
This PR decodes URI component for username and password for SOCKS tunnel. This is already done inside the library used for forward SOCKS, so I'm adding it to chain SOCKS as well.

Closes #548