### PR TITLE
chore: minor test enhancements

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,7 +3,12 @@ To run the tests, you need to add the following line to your `/etc/hosts`:
 
 ```
 # Used by proxy-chain NPM package tests
+127.0.0.1 localhost
 127.0.0.1 localhost-test
 ```
 
-This is a workaround to PhantomJS' behavior where it skips proxy servers for localhost addresses.
+The `localhost` entry is for avoiding dual-stack issues, e.g. when the test server listens at ::1
+(results of getaddrinfo have specifed order) and the client attempts to connect to 127.0.0.1 .
+
+The `localhost-test` entry is a workaround to PhantomJS' behavior where it skips proxy servers for
+localhost addresses.

--- a/test/server.js
+++ b/test/server.js
@@ -855,7 +855,12 @@ const createTestSuite = ({
                 // For SSL, we need to return curl's stderr to check what kind of error was there
                 const output = await curlGet(curlUrl, `http://bad:password@127.0.0.1:${mainProxyServerPort}`, !useSsl);
                 if (useSsl) {
-                    expect(output).to.contain('Received HTTP code 407 from proxy after CONNECT');
+                    expect(output).to.contain.oneOf([
+                        // Old error message before dafdb20a26d0c890e83dea61a104b75408481ebd
+                        'Received HTTP code 407 from proxy after CONNECT',
+                        // and that after
+                        'CONNECT tunnel failed, response 407',
+                    ]);
                 } else {
                     expect(output).to.contain('Proxy credentials required');
                 }


### PR DESCRIPTION
So that the tests may pass in my local environment (tried Node.js 20 (active LTS) and 18).

The CI tests however seem to be [configured to run only with Node.js 14 and 16](https://github.com/apify/proxy-chain/blob/b326f95855680cae28e80518a16662124e12c438/.github/workflows/check.yaml#L18).