### PR TITLE
fix: set target socket max listeners to infinity

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -88,6 +88,9 @@ export const chain = (
     client.on('connect', (response, targetSocket, clientHead) => {
         countTargetBytes(sourceSocket, targetSocket);
 
+        // There may be many .on('close') listeners, so we need to increase the limit.
+        targetSocket.setMaxListeners(Infinity);
+
         if (sourceSocket.readyState !== 'open') {
             // Sanity check, should never reach.
             targetSocket.destroy();

--- a/src/chain_socks.ts
+++ b/src/chain_socks.ts
@@ -82,6 +82,8 @@ export const chainSocks = async ({
             destination,
         });
         targetSocket = client.socket;
+        // There may be many .on('close') listeners, so we need to increase the limit.
+        targetSocket.setMaxListeners(Infinity);
 
         sourceSocket.write(`HTTP/1.1 200 Connection Established\r\n\r\n`);
     } catch (error) {

--- a/src/direct.ts
+++ b/src/direct.ts
@@ -69,6 +69,8 @@ export const direct = (
             sourceSocket.destroy(error as Error);
         }
     });
+    // There may be many .on('close') listeners, so we need to increase the limit.
+    targetSocket.setMaxListeners(Infinity);
 
     countTargetBytes(sourceSocket, targetSocket);
 


### PR DESCRIPTION
It happens that `targetSocket` has many `.on('close', ...)` listeners and we get `MaxListenersExceededWarning`. I increase the limit to infinity so we don't see such warnings.

I'd guess this is due to the fact that some target sockets can be reused/kept alive and therefore they have more on close listeners attached from several source sockets.