### PR TITLE
fixed missing log prefix for the first request

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -184,7 +184,7 @@ export class Server extends EventEmitter {
 
     log(connectionId: unknown, str: string): void {
         if (this.verbose) {
-            const logPrefix = connectionId ? `${String(connectionId)} | ` : '';
+            const logPrefix = connectionId != null ? `${String(connectionId)} | ` : '';
             // eslint-disable-next-line no-console
             console.log(`ProxyServer[${this.port}]: ${logPrefix}${str}`);
         }


### PR DESCRIPTION
The connection ID log prefix for the first request is missing because `connectionId` starts from 0.