### PR TITLE
fixed traffic stats for http connection reuse

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -7,6 +7,7 @@ import type { URL } from 'url';
 
 import type { Socket } from './socket';
 import { badGatewayStatusCodes, createCustomStatusHttpResponse, errorCodeToStatusCode } from './statuses';
+import type { SocketPreviousStats } from './utils/count_target_bytes';
 import { countTargetBytes } from './utils/count_target_bytes';
 import { getBasicAuthorizationHeader } from './utils/get_basic';
 
@@ -85,9 +86,15 @@ export const chain = (
     const fn = proxy.protocol === 'https:' ? https.request : http.request;
     const client = fn(proxy.origin, options as unknown as http.ClientRequestArgs);
 
-    client.on('connect', (response, targetSocket, clientHead) => {
+    client.once('socket', (targetSocket: Socket & SocketPreviousStats) => {
+        // socket can be re-used by multiple requests (HTTP keep alive)
+        // (even in multiple Server objects)
+        targetSocket.previousBytesRead = targetSocket.bytesRead;
+        targetSocket.previousBytesWritten = targetSocket.bytesWritten;
         countTargetBytes(sourceSocket, targetSocket);
+    });
 
+    client.on('connect', (response, targetSocket, clientHead) => {
         if (sourceSocket.readyState !== 'open') {
             // Sanity check, should never reach.
             targetSocket.destroy();

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -5,9 +5,10 @@ import stream from 'stream';
 import type { URL } from 'url';
 import util from 'util';
 
-import { Socket } from './socket';
+import type { Socket } from './socket';
 import { badGatewayStatusCodes, errorCodeToStatusCode } from './statuses';
-import { countTargetBytes, SocketPreviousStats } from './utils/count_target_bytes';
+import type { SocketPreviousStats } from './utils/count_target_bytes';
+import { countTargetBytes } from './utils/count_target_bytes';
 import { getBasicAuthorizationHeader } from './utils/get_basic';
 import { validHeadersOnly } from './utils/valid_headers_only';
 

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -5,8 +5,9 @@ import stream from 'stream';
 import type { URL } from 'url';
 import util from 'util';
 
+import { Socket } from './socket';
 import { badGatewayStatusCodes, errorCodeToStatusCode } from './statuses';
-import { countTargetBytes } from './utils/count_target_bytes';
+import { countTargetBytes, SocketPreviousStats } from './utils/count_target_bytes';
 import { getBasicAuthorizationHeader } from './utils/get_basic';
 import { validHeadersOnly } from './utils/valid_headers_only';
 
@@ -114,8 +115,12 @@ export const forward = async (
         }
     });
 
-    client.once('socket', (socket) => {
-        countTargetBytes(request.socket, socket);
+    client.once('socket', (socket: Socket & SocketPreviousStats) => {
+        // socket can be re-used by multiple requests (HTTP keep alive)
+        // (even in multiple Server objects)
+        socket.previousBytesRead = socket.bytesRead;
+        socket.previousBytesWritten = socket.bytesWritten;
+        countTargetBytes(request.socket, socket, (handler) => response.once('close', handler));
     });
 
     // Can't use pipeline here as it automatically destroys the streams

--- a/src/utils/count_target_bytes.ts
+++ b/src/utils/count_target_bytes.ts
@@ -7,17 +7,23 @@ const calculateTargetStats = Symbol('calculateTargetStats');
 
 type Stats = { bytesWritten: number | null, bytesRead: number | null };
 
+export type SocketPreviousStats = { previousBytesWritten?: number, previousBytesRead?: number };
+
 interface Extras {
     [targetBytesWritten]: number;
     [targetBytesRead]: number;
-    [targets]: Set<net.Socket>;
+    [targets]: Set<net.Socket & SocketPreviousStats>;
     [calculateTargetStats]: () => Stats;
 }
 
 // @ts-expect-error TS is not aware that `source` is used in the assertion.
 function typeSocket(source: unknown): asserts source is net.Socket & Extras {}
 
-export const countTargetBytes = (source: net.Socket, target: net.Socket): void => {
+export const countTargetBytes = (
+    source: net.Socket,
+    target: net.Socket & SocketPreviousStats,
+    finishRegister?: (handler: () => void) => void,
+): void => {
     typeSocket(source);
 
     source[targetBytesWritten] = source[targetBytesWritten] || 0;
@@ -26,12 +32,15 @@ export const countTargetBytes = (source: net.Socket, target: net.Socket): void =
 
     source[targets].add(target);
 
-    target.once('close', () => {
-        source[targetBytesWritten] += target.bytesWritten;
-        source[targetBytesRead] += target.bytesRead;
-
+    const finishHandler = () => {
+        source[targetBytesWritten] += (target.bytesWritten - (target.previousBytesWritten || 0));
+        source[targetBytesRead] += (target.bytesRead - (target.previousBytesRead || 0));
         source[targets].delete(target);
-    });
+    };
+    if (!finishRegister) {
+        finishRegister = (handler: () => void) => target.once('close', handler);
+    }
+    finishRegister(finishHandler);
 
     if (!source[calculateTargetStats]) {
         source[calculateTargetStats] = () => {
@@ -39,8 +48,8 @@ export const countTargetBytes = (source: net.Socket, target: net.Socket): void =
             let bytesRead = source[targetBytesRead];
 
             for (const socket of source[targets]) {
-                bytesWritten += socket.bytesWritten;
-                bytesRead += socket.bytesRead;
+                bytesWritten += (socket.bytesWritten - (socket.previousBytesWritten || 0));
+                bytesRead += (socket.bytesRead - (socket.previousBytesRead || 0));
             }
 
             return {


### PR DESCRIPTION
### Description of the issue
For plain HTTP requests using the `forward` method, it establishes an HTTP connection to the upstream proxy (or target website if no upstream proxy is specified) using the HTTP client library `http.request`.

So here the `target` is the TCP connection created or reused by the `http.request` call.
It relies on `target.once('close')`, `target.bytesRead` and `target.bytesWritten` for traffic stats, but it does not work well for certain cases, because the TCP connection can be reused, but it's not considered for the traffic stats logic.


### Environment to reproduce the issue
proxy-chain version: 2.5.6

Let's use two URLs:

- http://httpbin.org/flasgger_static/lib/jquery.min.js   ~85Kb Javascript resource
- http://httpbin.org/ip    ~200 bytes

<details><summary>Node.js server script</summary>

```javascript
const ProxyChain = require("proxy-chain");

(async () => {
    const proxyServer = new ProxyChain.Server({
        port: 6001,
        verbose: true,
        prepareRequestFunction: () => {
            return {
                upstreamProxyUrl: "http://<my-upstream-proxy-address>/",
            };
        },
    });
    proxyServer.on('connectionClosed', ({stats}) => console.log('stats from connectionClosed', stats));
    await proxyServer.listen();
    await new Promise((r) => {});
})();
```
</details>


### case 1 - `target` socket reused by multiple requests is closed before the `source` is closed
<details><summary>Client python script to reproduce</summary>

```python
import time
import requests

s = requests.Session()
proxies = {'http': 'http://localhost:6001'}

s.get('http://httpbin.org/flasgger_static/lib/jquery.min.js', proxies=proxies)
s.get('http://httpbin.org/ip', proxies=proxies)


time.sleep(10)
```
</details>

<details><summary>server output</summary>

```
ProxyServer[6001]: Listening...
ProxyServer[6001]: !!! Handling GET http://httpbin.org/flasgger_static/lib/jquery.min.js HTTP/1.1
ProxyServer[6001]: Using upstream proxy http://<my-upstream-proxy-addr>/
ProxyServer[6001]: Using forward()
ProxyServer[6001]: !!! Handling GET http://httpbin.org/ip HTTP/1.1
ProxyServer[6001]: Using upstream proxy http://<my-upstream-proxy-addr>/
ProxyServer[6001]: Using forward()
stats from connectionClosed {
  srcTxBytes: 86257,
  srcRxBytes: 355,
  trgTxBytes: 986,
  trgRxBytes: 172422
}
```
</details>

The `trgRxBytes` and `trgTxBytes` are doubled, because it registers `socket.once('close')` for every request, and when it's triggered, the 2 requests are finished using the same `target` socket, and the traffic of two requests is counted twice.


### case 2 - `target` socket reused by multiple requests using different `source`
<details><summary>Client curl commands to reproduce</summary>

```shell
curl -x http://localhost:6001/ http://httpbin.org/flasgger_static/lib/jquery.min.js > /dev/null
curl  -x http://localhost:6001/ http://httpbin.org/ip > /dev/null
```
</details>

<details><summary>server output</summary>

```
ProxyServer[6001]: 1 | !!! Handling GET http://httpbin.org/flasgger_static/lib/jquery.min.js HTTP/1.1
ProxyServer[6001]: 1 | Using upstream proxy http://<my-upstream-proxy-addr>/
ProxyServer[6001]: 1 | Using forward()
stats from connectionClosed {
  srcTxBytes: 85998,
  srcRxBytes: 156,
  trgTxBytes: 249,
  trgRxBytes: 85975
}
ProxyServer[6001]: 2 | !!! Handling GET http://httpbin.org/ip HTTP/1.1
ProxyServer[6001]: 2 | Using upstream proxy http://<my-upstream-proxy-addr>/
ProxyServer[6001]: 2 | Using forward()
stats from connectionClosed {
  srcTxBytes: 259,
  srcRxBytes: 125,
  trgTxBytes: 467,
  trgRxBytes: 86211
}
```
</details>

The `trgRxBytes` and `trgTxBytes` for the second request include the bytes from the first request, because `target` is reused and `target.bytesRead` includes the bytes from the first request.

### The fix
The fix is to track the number of bytes which is already there, when a socket is being allocated to an HTTP request, reduce it when calculating the stats, and use `response.once('close')` instead of `target.once('close')` to track the stats in the request life cycle.

