### PR TITLE
fix: correct target stats when sockets are reused

### DIFF
--- a/.github/scripts/before-beta-release.js
+++ b/.github/scripts/before-beta-release.js
@@ -1,9 +1,10 @@
-const path = require('path');
-const fs = require('fs');
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const PKG_JSON_PATH = path.join(__dirname, '..', '..', 'package.json');
 
+// eslint-disable-next-line import/no-dynamic-require
 const pkgJson = require(PKG_JSON_PATH);
 
 const PACKAGE_NAME = pkgJson.name;
@@ -13,20 +14,20 @@ const nextVersion = getNextVersion(VERSION);
 console.log(`before-deploy: Setting version to ${nextVersion}`);
 pkgJson.version = nextVersion;
 
-fs.writeFileSync(PKG_JSON_PATH, JSON.stringify(pkgJson, null, 2) + '\n');
+fs.writeFileSync(PKG_JSON_PATH, `${JSON.stringify(pkgJson, null, 2)}\n`);
 
 function getNextVersion(version) {
-    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8'});
+    const versionString = execSync(`npm show ${PACKAGE_NAME} versions --json`, { encoding: 'utf8' });
     const versions = JSON.parse(versionString);
 
-    if (versions.some(v => v === VERSION)) {
+    if (versions.some((v) => v === VERSION)) {
         console.error(`before-deploy: A release with version ${VERSION} already exists. Please increment version accordingly.`);
         process.exit(1);
     }
 
     const prereleaseNumbers = versions
-        .filter(v => (v.startsWith(VERSION) && v.includes('-')))
-        .map(v => Number(v.match(/\.(\d+)$/)[1]));
+        .filter((v) => (v.startsWith(VERSION) && v.includes('-')))
+        .map((v) => Number(v.match(/\.(\d+)$/)[1]));
     const lastPrereleaseNumber = Math.max(-1, ...prereleaseNumbers);
-    return `${version}-beta.${lastPrereleaseNumber + 1}`
+    return `${version}-beta.${lastPrereleaseNumber + 1}`;
 }

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,19 +62,13 @@ jobs:
                 uses: actions/setup-node@v1
                 with:
                     node-version: 18
-            # -
-            #     name: Load Cache
-            #     uses: actions/cache@v4
-            #     with:
-            #         path: |
-            #             node_modules
-            #             build
-            #         key: cache-${{ github.run_id }}-v18
             -
-                name: Check local directory
-                run: ls -la
-            -
-                name: Install Dependencies
-                run: npm install
+                name: Load Cache
+                uses: actions/cache@v4
+                with:
+                    path: |
+                        node_modules
+                        build
+                    key: cache-${{ github.run_id }}-v18
             -
                 run: npm run lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,13 +62,16 @@ jobs:
                 uses: actions/setup-node@v1
                 with:
                     node-version: 18
+            # -
+            #     name: Load Cache
+            #     uses: actions/cache@v4
+            #     with:
+            #         path: |
+            #             node_modules
+            #             build
+            #         key: cache-${{ github.run_id }}-v18
             -
-                name: Load Cache
-                uses: actions/cache@v4
-                with:
-                    path: |
-                        node_modules
-                        build
-                    key: cache-${{ github.run_id }}-v18
+                name: Install Dependencies
+                run: npm install
             -
                 run: npm run lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -71,6 +71,9 @@ jobs:
             #             build
             #         key: cache-${{ github.run_id }}-v18
             -
+                name: Check local directory
+                run: ls -la
+            -
                 name: Install Dependencies
                 run: npm install
             -

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
             -
                 name: Cache Node Modules
                 if: ${{ matrix.node-version == 18 }}
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: |
                         node_modules
@@ -64,7 +64,7 @@ jobs:
                     node-version: 18
             -
                 name: Load Cache
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: |
                         node_modules

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       -
         name: Cache Node Modules
         if: ${{ matrix.node-version == 18 }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -67,7 +67,7 @@ jobs:
           node-version: 18
       -
         name: Load Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -93,7 +93,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       -
         name: Load Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import apify from '@apify/eslint-config';
 
 // eslint-disable-next-line import/no-default-export
 export default [
-    { ignores: ['**/dist'] }, // Ignores need to happen first
+    { ignores: ['**/dist', 'test'] }, // Ignores need to happen first
     ...apify,
     {
         languageOptions: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from '@jest/types';
 
+// eslint-disable-next-line import/no-default-export
 export default (): Config.InitialOptions => ({
     verbose: true,
     preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.5.8",
+  "version": "2.5.7",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepublishOnly": "npm run build",
     "local-proxy": "node ./dist/run_locally.js",
     "test": "nyc cross-env NODE_OPTIONS=--insecure-http-parser mocha --bail",
-    "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepublishOnly": "npm run build",
     "local-proxy": "node ./dist/run_locally.js",
     "test": "nyc cross-env NODE_OPTIONS=--insecure-http-parser mocha --bail",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix"
+    "lint": "eslint ./src",
+    "lint:fix": "eslint ./src --fix"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
This PR attempts to fix incorrect stats due to the reuse of target sockets for HTTP(S) protocols. 

Based on https://github.com/apify/proxy-chain/pull/572

Note: I was forced to upgrade `actions/cache` as `v2` was deprecated and it wouldn't run with it.
I also had to edit eslint config to run with `.` instead of `src` and excluded `tests`, because with `src` the CI was failing (no idea why). 

The files changed in `src` are the ones relevant for the main topic of this PR.