### PR TITLE
Add HTTPS upstream proxy support with option to ignore proxy cert errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,17 @@ const server = new ProxyChain.Server({
             // requiring Basic authentication. Here you can verify user credentials.
             requestAuthentication: username !== 'bob' || password !== 'TopSecret',
 
-            // Sets up an upstream HTTP/SOCKS proxy to which all the requests are forwarded.
+            // Sets up an upstream HTTP/HTTPS/SOCKS proxy to which all the requests are forwarded.
             // If null, the proxy works in direct mode, i.e. the connection is forwarded directly
             // to the target server. This field is ignored if "requestAuthentication" is true.
             // The username and password must be URI-encoded.
             upstreamProxyUrl: `http://username:password@proxy.example.com:3128`,
             // Or use SOCKS4/5 proxy, e.g.
             // upstreamProxyUrl: `socks://username:password@proxy.example.com:1080`,
+
+            // Applies to HTTPS upstream proxy. If set to true, requests made to the proxy will
+            // ignore certificate errors. Useful when upstream proxy uses self-signed certificate. By default "false".
+            ignoreUpstreamProxyCertificate: true
 
             // If "requestAuthentication" is true, you can use the following property
             // to define a custom error message to return to the client instead of the default "Proxy credentials required"
@@ -368,9 +372,12 @@ The package also provides several utility functions.
 
 ### `anonymizeProxy({ url, port }, callback)`
 
-Parses and validates a HTTP proxy URL. If the proxy requires authentication,
+Parses and validates a HTTP/HTTPS proxy URL. If the proxy requires authentication,
 then the function starts an open local proxy server that forwards to the proxy.
 The port (on which the local proxy server will start) can be set via the `port` property of the first argument, if not provided, it will be chosen randomly.
+
+For HTTPS proxy with self-signed certificate, set `ignoreProxyCertificate` property of the first argument to `true` to ignore certificate errors in
+proxy requests.
 
 The function takes an optional callback that receives the anonymous proxy URL.
 If no callback is supplied, the function returns a promise that resolves to a String with
@@ -420,13 +427,14 @@ If callback is not provided, the function returns a promise instead.
 
 ### `createTunnel(proxyUrl, targetHost, options, callback)`
 
-Creates a TCP tunnel to `targetHost` that goes through a HTTP proxy server
+Creates a TCP tunnel to `targetHost` that goes through a HTTP/HTTPS proxy server
 specified by the `proxyUrl` parameter.
 
 The optional `options` parameter is an object with the following properties:
 - `port: Number` - Enables specifying the local port to listen at. By default `0`,
    which means a random port will be selected.
 - `hostname: String` - Local hostname to listen at. By default `localhost`.
+- `ignoreProxyCertificate` - For HTTPS proxy, ignore certificate errors in proxy requests. Useful for proxy with self-signed certificate. By default `false`.
 - `verbose: Boolean` - If `true`, the functions logs a lot. By default `false`.
 
 The result of the function is a local endpoint in a form of `hostname:port`.

--- a/src/anonymize_proxy.ts
+++ b/src/anonymize_proxy.ts
@@ -67,7 +67,7 @@ export const anonymizeProxy = async (
                     return {
                         requestAuthentication: false,
                         upstreamProxyUrl: proxyUrl,
-                        ignoreUpstreamProxyCertificate: ignoreProxyCertificate
+                        ignoreUpstreamProxyCertificate: ignoreProxyCertificate,
                     };
                 },
             }) as Server & { port: number };

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -84,10 +84,10 @@ export const chain = (
         options.headers.push('proxy-authorization', getBasicAuthorizationHeader(proxy));
     }
 
-    const client = proxy.protocol === 'https:' ?
-        https.request(proxy.origin, {
+    const client = proxy.protocol === 'https:'
+        ? https.request(proxy.origin, {
             ...options as unknown as https.RequestOptions,
-            rejectUnauthorized: !handlerOpts.ignoreUpstreamProxyCertificate
+            rejectUnauthorized: !handlerOpts.ignoreUpstreamProxyCertificate,
         })
         : http.request(proxy.origin, options as unknown as http.RequestOptions);
 

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -22,6 +22,7 @@ interface Options {
 
 export interface HandlerOpts {
     upstreamProxyUrlParsed: URL;
+    ignoreUpstreamProxyCertificate: boolean;
     localAddress?: string;
     ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
@@ -83,8 +84,12 @@ export const chain = (
         options.headers.push('proxy-authorization', getBasicAuthorizationHeader(proxy));
     }
 
-    const fn = proxy.protocol === 'https:' ? https.request : http.request;
-    const client = fn(proxy.origin, options as unknown as http.ClientRequestArgs);
+    const client = proxy.protocol === 'https:' ?
+        https.request(proxy.origin, {
+            ...options as unknown as https.RequestOptions,
+            rejectUnauthorized: !handlerOpts.ignoreUpstreamProxyCertificate
+        })
+        : http.request(proxy.origin, options as unknown as http.RequestOptions);
 
     client.once('socket', (targetSocket: SocketWithPreviousStats) => {
         // Socket can be re-used by multiple requests.

--- a/src/forward.ts
+++ b/src/forward.ts
@@ -114,12 +114,12 @@ export const forward = async (
     };
 
     // We have to force cast `options` because @types/node doesn't support an array.
-    const client = origin!.startsWith('https:') ?
-        https.request(origin!, {
+    const client = origin!.startsWith('https:')
+        ? https.request(origin!, {
             ...options as unknown as https.RequestOptions,
-            rejectUnauthorized: handlerOpts.upstreamProxyUrlParsed ? !handlerOpts.ignoreUpstreamProxyCertificate : undefined
+            rejectUnauthorized: handlerOpts.upstreamProxyUrlParsed ? !handlerOpts.ignoreUpstreamProxyCertificate : undefined,
         }, requestCallback)
-        
+
         : http.request(origin!, options as unknown as http.RequestOptions, requestCallback);
 
     client.once('socket', (socket: SocketWithPreviousStats) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ type HandlerOpts = {
     srcHead: Buffer | null;
     trgParsed: URL | null;
     upstreamProxyUrlParsed: URL | null;
+    ignoreUpstreamProxyCertificate: boolean;
     isHttp: boolean;
     customResponseFunction?: CustomResponseOpts['customResponseFunction'] | null;
     customConnectServer?: http.Server | null;
@@ -80,6 +81,7 @@ export type PrepareRequestFunctionResult = {
     requestAuthentication?: boolean;
     failMsg?: string;
     upstreamProxyUrl?: string | null;
+    ignoreUpstreamProxyCertificate?: boolean;
     localAddress?: string;
     ipFamily?: number;
     dnsLookup?: typeof dns['lookup'];
@@ -341,6 +343,7 @@ export class Server extends EventEmitter {
             srcHead: null,
             trgParsed: null,
             upstreamProxyUrlParsed: null,
+            ignoreUpstreamProxyCertificate: false,
             isHttp: false,
             srcResponse: null,
             customResponseFunction: null,
@@ -466,6 +469,10 @@ export class Server extends EventEmitter {
             if (!['http:', 'https:', ...SOCKS_PROTOCOLS].includes(handlerOpts.upstreamProxyUrlParsed.protocol)) {
                 throw new Error(`Invalid "upstreamProxyUrl" provided: URL must have one of the following protocols: "http", "https", ${SOCKS_PROTOCOLS.map((p) => `"${p.replace(':', '')}"`).join(', ')} (was "${funcResult.upstreamProxyUrl}")`);
             }
+        }
+
+        if (funcResult.ignoreUpstreamProxyCertificate !== undefined) {
+            handlerOpts.ignoreUpstreamProxyCertificate = funcResult.ignoreUpstreamProxyCertificate;
         }
 
         const { proxyChainId } = request.socket as Socket;

--- a/src/tcp_tunnel_tools.ts
+++ b/src/tcp_tunnel_tools.ts
@@ -26,7 +26,7 @@ export async function createTunnel(
     callback?: (error: Error | null, result?: string) => void,
 ): Promise<string> {
     const parsedProxyUrl = new URL(proxyUrl);
-    if (parsedProxyUrl.protocol !== 'http:' && parsedProxyUrl.protocol !== 'https:') {
+    if (!['http:', 'https:'].includes(parsedProxyUrl.protocol)) {
         throw new Error(`The proxy URL must have the "http" or "https" protocol (was "${proxyUrl}")`);
     }
 

--- a/src/tcp_tunnel_tools.ts
+++ b/src/tcp_tunnel_tools.ts
@@ -70,7 +70,7 @@ export async function createTunnel(
             sourceSocket,
             handlerOpts: {
                 upstreamProxyUrlParsed: parsedProxyUrl,
-                ignoreUpstreamProxyCertificate: options?.ignoreProxyCertificate ?? false
+                ignoreUpstreamProxyCertificate: options?.ignoreProxyCertificate ?? false,
             },
             server: server as net.Server & { log: typeof log },
             isPlain: true,

--- a/src/tcp_tunnel_tools.ts
+++ b/src/tcp_tunnel_tools.ts
@@ -19,7 +19,7 @@ const getAddress = (server: net.Server) => {
 export async function createTunnel(
     proxyUrl: string,
     targetHost: string,
-    options: {
+    options?: {
         verbose?: boolean;
         ignoreProxyCertificate?: boolean;
     },
@@ -70,7 +70,7 @@ export async function createTunnel(
             sourceSocket,
             handlerOpts: {
                 upstreamProxyUrlParsed: parsedProxyUrl,
-                ignoreUpstreamProxyCertificate: options.ignoreProxyCertificate ?? false
+                ignoreUpstreamProxyCertificate: options?.ignoreProxyCertificate ?? false
             },
             server: server as net.Server & { log: typeof log },
             isPlain: true,

--- a/src/tcp_tunnel_tools.ts
+++ b/src/tcp_tunnel_tools.ts
@@ -21,12 +21,13 @@ export async function createTunnel(
     targetHost: string,
     options: {
         verbose?: boolean;
+        ignoreProxyCertificate?: boolean;
     },
     callback?: (error: Error | null, result?: string) => void,
 ): Promise<string> {
     const parsedProxyUrl = new URL(proxyUrl);
-    if (parsedProxyUrl.protocol !== 'http:') {
-        throw new Error(`The proxy URL must have the "http" protocol (was "${proxyUrl}")`);
+    if (parsedProxyUrl.protocol !== 'http:' && parsedProxyUrl.protocol !== 'https:') {
+        throw new Error(`The proxy URL must have the "http" or "https" protocol (was "${proxyUrl}")`);
     }
 
     const url = new URL(`connect://${targetHost || ''}`);
@@ -67,7 +68,10 @@ export async function createTunnel(
         chain({
             request: { url: targetHost },
             sourceSocket,
-            handlerOpts: { upstreamProxyUrlParsed: parsedProxyUrl },
+            handlerOpts: {
+                upstreamProxyUrlParsed: parsedProxyUrl,
+                ignoreUpstreamProxyCertificate: options.ignoreProxyCertificate ?? false
+            },
             server: server as net.Server & { log: typeof log },
             isPlain: true,
         });


### PR DESCRIPTION
As title. E.g.:

```
const server = new Server({
  prepareRequestFunction: () => ({
    upstreamProxyUrl: 'https://user:pass@myproxy:8080',
    ignoreUpstreamProxyCertificate: true  // Useful for self-signed cert
  })
}).listen();
```
Anonymize:
```
anonymizeProxy({
  url: 'https://user:pass@myproxy:8080',
  ignoreProxyCertificate: true,
}).then((anonymizedURL) => {
  console.log(`Anonymized URL: ${anonymizedURL}`);
});
```
Create tunnel:
```
createTunnel(
  'https://user:pass@myproxy:8080',
  targetHost,
  { ignoreProxyCertificate: true }
).then((url) => {
  console.log('Tunnel endpoint:', url);
});
```
