### PR TITLE
test: add ignoreUpstreamProxyCertificate tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy-chain",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
   "main": "dist/index.js",
   "keywords": [

--- a/test/server.js
+++ b/test/server.js
@@ -1481,7 +1481,7 @@ it('supports pre-response CONNECT payload', (done) => {
     });
 });
 
-describe('supports ignoreProxyCertificate', () => {
+describe('supports ignoreUpstreamProxyCertificate', () => {
     const serverOptions = {
         key: sslKey,
         cert: sslCrt,

--- a/test/server.js
+++ b/test/server.js
@@ -1514,6 +1514,10 @@ describe('supports ignoreUpstreamProxyCertificate', () => {
 
         await proxyServer.listen();
 
+        /**
+         * request is sent with rejectUnauthorized: true
+         * so when the SSL certificate is not trusted (self-signed, expired, invalid), client will reject the connection
+         */
         const response = await requestPromised({
             proxy: 'http://localhost:6666',
             url: 'http://httpbin.org/ip',
@@ -1553,6 +1557,10 @@ describe('supports ignoreUpstreamProxyCertificate', () => {
 
         await proxyServer.listen();
 
+        /**
+         * request is sent with rejectUnauthorized: false
+         * so when the SSL certificate is not trusted (self-signed, expired, invalid), client won't reject the connection
+         */
         const response = await requestPromised({
             proxy: 'http://localhost:6666',
             url: 'http://httpbin.org/ip',

--- a/test/server.js
+++ b/test/server.js
@@ -1481,6 +1481,93 @@ it('supports pre-response CONNECT payload', (done) => {
     });
 });
 
+describe('supports ignoreProxyCertificate', () => {
+    const serverOptions = {
+        key: sslKey,
+        cert: sslCrt,
+    };
+
+    const responseMessage = 'Hello World!';
+
+    it('fails on upstream error', async () => {
+        const target = https.createServer(serverOptions, (_req, res) => {
+            res.write(responseMessage);
+            res.end();
+        });
+
+        await util.promisify(target.listen.bind(target))(0);
+
+        const proxyServer = new ProxyChain.Server({
+            port: 6666,
+            prepareRequestFunction: () => {
+                return {
+                    upstreamProxyUrl: `https://localhost:${target.address().port}`,
+                };
+            },
+        });
+
+        let proxyServerError = false;
+        proxyServer.on('requestFailed', () => {
+            // requestFailed will be called if we pass an invalid proxy url
+            proxyServerError = true;
+        });
+
+        await proxyServer.listen();
+
+        const response = await requestPromised({
+            proxy: 'http://localhost:6666',
+            url: 'http://httpbin.org/ip',
+        });
+
+        expect(proxyServerError).to.be.equal(false);
+
+        expect(response.statusCode).to.be.equal(599);
+
+        proxyServer.close();
+        target.close();
+    });
+
+    it('bypass upstream error', async () => {
+        const target = https.createServer(serverOptions, (_req, res) => {
+            res.write(responseMessage);
+            res.end();
+        });
+
+        await util.promisify(target.listen.bind(target))(0);
+
+        const proxyServer = new ProxyChain.Server({
+            port: 6666,
+            prepareRequestFunction: () => {
+                return {
+                    ignoreUpstreamProxyCertificate: true,
+                    upstreamProxyUrl: `https://localhost:${target.address().port}`,
+                };
+            },
+        });
+
+        let proxyServerError = false;
+        proxyServer.on('requestFailed', () => {
+            // requestFailed will be called if we pass an invalid proxy url
+            proxyServerError = true;
+        });
+
+        await proxyServer.listen();
+
+        const response = await requestPromised({
+            proxy: 'http://localhost:6666',
+            url: 'http://httpbin.org/ip',
+        });
+
+        expect(proxyServerError).to.be.equal(false);
+
+        expect(response.statusCode).to.be.equal(200);
+        expect(response.body).to.be.equal(responseMessage);
+
+        proxyServer.close();
+        target.close();
+    });
+});
+
 // Run all combinations of test parameters
 const useSslVariants = [
     false,


### PR DESCRIPTION
Add tests for `ignoreUpstreamProxyCertificate` proxy chain server `prepareRequestFunction` option.