### PR TITLE
feat: add connection event

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -213,6 +213,10 @@ export class Server extends EventEmitter {
         socket.proxyChainId = unique;
         this.connections.set(unique, socket);
 
+        this.emit('connectionOpen', {
+            connectionId: unique,
+        });
+
         socket.on('close', () => {
             this.emit('connectionClosed', {
                 connectionId: unique,

--- a/src/server.ts
+++ b/src/server.ts
@@ -213,7 +213,8 @@ export class Server extends EventEmitter {
         socket.proxyChainId = unique;
         this.connections.set(unique, socket);
 
-        this.emit('connectionEstablished', {
+        // Emit this after storing the connection to ensure listeners can reliably access the socket using the connectionId.
+        this.emit('connection', {
             connectionId: unique,
         });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -213,7 +213,7 @@ export class Server extends EventEmitter {
         socket.proxyChainId = unique;
         this.connections.set(unique, socket);
 
-        this.emit('connectionOpen', {
+        this.emit('connectionEstablished', {
             connectionId: unique,
         });
 

--- a/test/server.js
+++ b/test/server.js
@@ -411,7 +411,7 @@ const createTestSuite = ({
 
                     mainProxyServer = new Server(opts);
 
-                    mainProxyServer.on('connectionEstablished', ({ connectionId }) => {
+                    mainProxyServer.on('connection', ({ connectionId }) => {
                         assert.include(mainProxyServer.getConnectionIds(), connectionId);
                     });
 

--- a/test/server.js
+++ b/test/server.js
@@ -411,6 +411,10 @@ const createTestSuite = ({
 
                     mainProxyServer = new Server(opts);
 
+                    mainProxyServer.on('connectionEstablished', ({ connectionId }) => {
+                        assert.include(mainProxyServer.getConnectionIds(), connectionId);
+                    });
+
                     mainProxyServer.on('connectionClosed', ({ connectionId, stats }) => {
                         assert.include(mainProxyServer.getConnectionIds(), connectionId);
                         mainProxyServerConnectionsClosed.push(connectionId);


### PR DESCRIPTION
This PR introduces a new connection event. It's triggered whenever a new client connects, and the event payload contains the connectionId of the new socket. It's needed to create connection manager in https://github.com/apify/apify-proxy/issues/1062.