### PR TITLE
Emit event `tunnelError` when the tunnel has an error

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -137,6 +137,7 @@ export const chain = (
                 proxyChainId,
                 response,
                 customTag,
+                statusCode: response.statusCode,
                 socket: targetSocket,
                 head: clientHead,
             });
@@ -190,7 +191,7 @@ export const chain = (
         if (sourceSocket.readyState === 'open') {
             if (isPlain) {
                 sourceSocket.end();
-                
+
                 server.emit('tunnelError', {
                     error,
                     proxyChainId,


### PR DESCRIPTION
When an error happens in the chaining it is only logged, but not emitted. I created the event `tunnelError` that emit the error related to the tunnel.