### PR TITLE
perf: do not publish `tsbuildinfo` file to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     },
     "homepage": "https://blog.apify.com/how-to-make-headless-chrome-and-puppeteer-use-a-proxy-server-with-authentication-249a21a79212",
     "files": [
-        "dist"
+        "dist",
+        "!**/*.tsbuildinfo"
     ],
     "scripts": {
         "build:watch": "tsc -w",


### PR DESCRIPTION
Shrinks the package size by 13kB compressed or 35kB uncompressed space.