### PR TITLE
fix: add missing resolve() when headers are already send using forward handlers

### DIFF
--- a/src/forward.ts
+++ b/src/forward.ts
@@ -140,6 +140,7 @@ export const forward = async (
     request.pipe(client);
     client.on('error', (error: NodeJS.ErrnoException) => {
         if (response.headersSent) {
+            resolve();
             return;
         }
 

--- a/src/forward_socks.ts
+++ b/src/forward_socks.ts
@@ -96,6 +96,7 @@ export const forwardSocks = async (
     request.pipe(client);
     client.on('error', (error: NodeJS.ErrnoException) => {
         if (response.headersSent) {
+            resolve();
             return;
         }
 


### PR DESCRIPTION
Both forward and forward_socks are affected.

Found this during HTTPS scope split. Based on my investigation, the specific bug condition (client.on('error') firing after response.headersSent is true) appears to not possible to trigger reliably (or it's just my skill issue).

I used `resolve()` but not `reject()` to be consistent with `pipeline()` catch block which also calls `resolve()`.