### PR TITLE
fix: correct localhost-test resolving on linux machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "prepublishOnly": "npm run build",
         "local-proxy": "node ./dist/run_locally.js",
         "test": "nyc cross-env NODE_OPTIONS=--insecure-http-parser mocha",
-        "test:docker": "docker build --tag proxy-chain-tests --file test/Dockerfile . && docker run proxy-chain-tests",
+        "test:docker": "docker build --tag proxy-chain-tests --file test/Dockerfile . && docker run --add-host localhost-test:127.0.0.1 proxy-chain-tests",
         "test:docker:all": "bash scripts/test-docker-all.sh",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix"

--- a/scripts/test-docker-all.sh
+++ b/scripts/test-docker-all.sh
@@ -3,11 +3,11 @@
 echo "Starting parallel Docker tests for Node 14, 16, and 18..."
 
 # Run builds in parallel, capture PIDs.
-docker build --build-arg NODE_IMAGE=node:14.21.3-bullseye --tag proxy-chain-tests:node14 --file test/Dockerfile . && docker run proxy-chain-tests:node14 &
+docker build --build-arg NODE_IMAGE=node:14.21.3-bullseye --tag proxy-chain-tests:node14 --file test/Dockerfile . && docker run --add-host localhost-test:127.0.0.1 proxy-chain-tests:node14 &
 pid14=$!
-docker build --build-arg NODE_IMAGE=node:16.20.2-bookworm --tag proxy-chain-tests:node16 --file test/Dockerfile . && docker run proxy-chain-tests:node16 &
+docker build --build-arg NODE_IMAGE=node:16.20.2-bookworm --tag proxy-chain-tests:node16 --file test/Dockerfile . && docker run --add-host localhost-test:127.0.0.1 proxy-chain-tests:node16 &
 pid16=$!
-docker build --build-arg NODE_IMAGE=node:18.20.8-bookworm --tag proxy-chain-tests:node18 --file test/Dockerfile . && docker run proxy-chain-tests:node18 &
+docker build --build-arg NODE_IMAGE=node:18.20.8-bookworm --tag proxy-chain-tests:node18 --file test/Dockerfile . && docker run --add-host localhost-test:127.0.0.1 proxy-chain-tests:node18 &
 pid18=$!
 
 # Wait for all and capture exit codes.


### PR DESCRIPTION
When run docker tests on linux machine `localhost-test` related tests are failing.

```bash
  1) Test localhost-test setup
  works:
  Error: getaddrinfo ENOTFOUND localhost-test
  at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
```

Also added proper server cleanup to https tests.