### PR TITLE
ci: soften devEngines onFail to warn under pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "packageManager": {
             "name": "pnpm",
             "version": "10.33.4",
-            "onFail": "error"
+            "onFail": "warn"
         }
     },
     "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
The publish workflow's "Bump pre-release version" step crashed with \`EBADDEVENGINES\` on the first beta release after #659 merged ([run](https://github.com/apify/proxy-chain/actions/runs/26219338774/job/77150345843)):

\`\`\`
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
npm error EBADDEVENGINES current:  { name: 'npm',  version: '11.12.1' }
npm error EBADDEVENGINES required: { name: 'pnpm', version: '10.33.4', onFail: 'error' }
\`\`\`

## Root cause

Two pnpm-10-specific behaviours from #659 we didn't fully account for:

1. **A long list of pnpm 10 subcommands are passthroughs to npm**, not native. Confirmed against [\`pnpm.ts\` at v10.33.4](https://github.com/pnpm/pnpm/blob/v10.33.4/pnpm/src/pnpm.ts) — the switch statement explicitly forwards: \`access, adduser, bugs, deprecate, dist-tag, docs, edit, find, home, info, issues, login, logout, owner, ping, prefix, profile, pkg, repo, search, set-script, show, star, stars, team, token, unpublish, unstar, version, view, whoami\`. pnpm 11 reimplements these natively (the code even has a comment about it).
2. **npm 11+ enforces \`devEngines.packageManager\` on every command**, not just install/lifecycle. npm 10 was warn-only — that's what the earlier "empirical verification" must have run against.

So \`pnpm view\` (used in \`before-beta-release.cjs\`) shells to \`npm view\`, which on a npm-11 runner trips devEngines under \`onFail: error\`.

## Fix

Soften \`devEngines.packageManager.onFail\`: \`error\` → \`warn\`.

\`error\` plus pnpm 10 is fragile for everyone: anyone running \`pnpm view\`, \`pnpm version\`, \`pnpm pkg\`, \`pnpm dist-tag\` locally — all common workflows — gets the same EBADDEVENGINES crash that has nothing to do with what they did. \`warn\` keeps the human signal against accidental \`npm install\` / \`yarn install\` without the cliff for pnpm's own shell-out commands.

Bump back to \`error\` when we drop Node 20 support and move to pnpm 11, where these subcommands are native (no warning, no crash).

## Audit

Workflows use \`pnpm install\` (via action), \`pnpm publish\`, \`pnpm run\`, \`pnpm rebuild\` — all verified native in pnpm 10's source (not in the passthrough switch). The only passthrough we currently invoke is \`pnpm view\` in \`before-beta-release.cjs\`, which now emits a warning in CI and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)