### PR TITLE
chore: stop publishing broken declaration and source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "target": "ES2022",
-        "verbatimModuleSyntax": true
+        "verbatimModuleSyntax": true,
+        "declarationMap": false,
+        "sourceMap": false
     },
     "include": ["src"]
 }


### PR DESCRIPTION
The published tarball excludes `src` but ships `.d.ts.map`/`.js.map` that reference `../src/*.ts`, so the maps never resolve — editors fall back to the compiled `.d.ts`/`.js` instead of the original source. Disabling `declarationMap`/`sourceMap` stops emitting these dead maps and shrinks the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)