### PR TITLE
chore(release): bump version to 3.0.1 for next dev cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "proxy-chain",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Node.js implementation of a proxy server (think Squid) with support for SSL, authentication, upstream proxy chaining, and protocol tunneling.",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
`3.0.0` was published to npm as `latest`, but `package.json` still pinned `3.0.0`. The beta release workflow ([`before-beta-release.cjs`](.github/scripts/before-beta-release.cjs)) aborts when the base version already exists on npm:

```
before-deploy: A release with version 3.0.0 already exists. Please increment version accordingly.
```

So every push to master failed at the **Bump pre-release version** step ([example run](https://github.com/apify/proxy-chain/actions/runs/26398985580/job/77706715093)) and no beta was published.

Bumping to `3.0.1` restores the dev cycle — master pushes now publish as `3.0.1-beta.N`, matching the existing convention (after `2.7.0` shipped, the repo moved to `2.7.1` → `2.7.1-beta.0`).