### PR TITLE
Fix invalid certificate error in tcp_tunnel_test by using wait helper

### DIFF
--- a/test/e2e/tcp_tunnel.js
+++ b/test/e2e/tcp_tunnel.js
@@ -6,6 +6,8 @@ import proxy from 'proxy';
 import { createTunnel, closeTunnel } from '../../src/index.js';
 import { expectThrowsAsync } from '../utils/throws_async.js';
 
+const wait = (timeout) => new Promise((resolve) => setTimeout(resolve, timeout));
+
 const destroySocket = (socket) => new Promise((resolve) => {
     if (!socket || socket.destroyed) return resolve();
     socket.once('close', () => resolve());


### PR DESCRIPTION
The tcp_tunnel test file was missing the wait helper needed by closeServer, causing a ReferenceError. Added the missing arrow function (identical to the one in server.js) to make the test runnable again.