### PR TITLE
chore(deps): bump websocket-driver to 0.7.5 to fix CVE-2026-54466

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2852,8 +2852,8 @@ packages:
   webdriver-bidi-protocol@0.4.2:
     resolution: {integrity: sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -4411,7 +4411,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6063,7 +6063,7 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.2: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
GHSA-xv26-6w52-cph6 (critical, CVSS 9.2): draft-protocol frame length headers let a client encode an arbitrarily large integer as a run of bytes with the high bit set. The parser accumulates it past 64-bit float precision, so the subsequent payload is framed incorrectly and messages corrupt. Fixed in 0.7.5 by rejecting length headers that exceed the configured maximum message length.

Lockfile-only change: `websocket-driver` is a transitive dev dependency of `faye-websocket`, which declares `>=0.5.1`, so 0.7.5 satisfies the existing range. No `package.json` edit and no `pnpm-workspace.yaml` override are needed, so there is nothing to unwind on a later bump.

Nothing published to npm was exposed. `faye-websocket` is a devDependency used only by the e2e WebSocket tests; runtime `dependencies` are just socks, socks-proxy-agent and tslib, and `files` publishes only `dist`.

Verified with the full unit + e2e suite on Node 20: 2190 passing, 0 failing, 0 pending.