### PR TITLE
fix: don't listen on every interface in createTunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ The optional `options` parameter is an object with the following properties:
 
 The result of the function is a local endpoint in a form of `hostname:port`,
 where `hostname` is the address the tunnel actually bound to. IPv6 addresses are
-bracketed, e.g. `[::1]:56836`. Pass this exact string to `closeTunnel()`.
+bracketed, e.g. `[::1]:56836`.
 
 All TCP connections made to the local endpoint will be tunneled through the proxy to the target host and port.
 For example, this is useful if you want to access a certain service from a specific IP address.

--- a/README.md
+++ b/README.md
@@ -560,18 +560,23 @@ specified by the `proxyUrl` parameter.
 The optional `options` parameter is an object with the following properties:
 - `port: Number` - Enables specifying the local port to listen at. By default `0`,
    which means a random port will be selected.
-- `hostname: String` - Local hostname to listen at. By default `localhost`.
+- `hostname: String` - Local hostname to listen at. By default `127.0.0.1`.
 - `ignoreProxyCertificate` - For HTTPS proxy, ignore certificate errors in proxy requests. Useful for proxy with self-signed certificate. By default `false`.
 - `verbose: Boolean` - If `true`, the functions logs a lot. By default `false`.
 
-The result of the function is a local endpoint in a form of `hostname:port`.
+The result of the function is a local endpoint in a form of `hostname:port`,
+where `hostname` is the address the tunnel actually bound to. IPv6 addresses are
+bracketed, e.g. `[::1]:56836`. Pass this exact string to `closeTunnel()`.
+
 All TCP connections made to the local endpoint will be tunneled through the proxy to the target host and port.
 For example, this is useful if you want to access a certain service from a specific IP address.
 
-The tunnel should be eventually closed by calling the `closeTunnel()` function.
+The tunnel does not authenticate its clients and forwards the `proxyUrl`
+credentials upstream, which is why it listens on `127.0.0.1` by default. Only
+pass a non-loopback `hostname` if you restrict access to it by other means -
+doing so emits a `ProxyChainSecurityWarning` via `process.emitWarning()`.
 
-The `createTunnel()` function returns a promise that resolves to a String with
-the path to the local endpoint.
+The tunnel should be eventually closed by calling the `closeTunnel()` function.
 
 For more information, read this [blog post](https://blog.apify.com/tunneling-arbitrary-protocols-over-http-proxy-with-static-ip-address-b3a2222191ff).
 
@@ -579,7 +584,7 @@ Example:
 
 ```javascript
 const host = await createTunnel('http://bob:pass123@proxy.example.com:8000', 'service.example.com:356');
-// Prints something like "localhost:56836"
+// Prints something like "127.0.0.1:56836"
 console.log(host);
 ```
 

--- a/examples/apify_proxy_tunnel.js
+++ b/examples/apify_proxy_tunnel.js
@@ -15,7 +15,7 @@ import { closeTunnel, createTunnel, redactUrl } from 'proxy-chain';
     const TARGET_HOST = 'www.example.com:443';
 
     // Create tunnel for the service, this call will start local tunnel and
-    // return a string in format localhost:<selected-port>.
+    // return a string in format 127.0.0.1:<selected-port>.
     // Here we set "port" to 9999, but you can use 0 to get a random port.
     // The "verbose" option causes a lot of logging
     const tunnelInfo = await createTunnel(PROXY_URL, TARGET_HOST, { port: 9999, verbose: true });

--- a/src/anonymize_proxy.ts
+++ b/src/anonymize_proxy.ts
@@ -31,6 +31,7 @@ export const anonymizeProxy = async (
         proxyUrl = options;
     } else {
         proxyUrl = options.url;
+        // Port 0 tells the OS to pick a free ephemeral port, which we read back after `listen()`.
         port = options.port ?? 0;
 
         validateListenPort(port);

--- a/src/anonymize_proxy.ts
+++ b/src/anonymize_proxy.ts
@@ -4,13 +4,14 @@ import type net from 'node:net';
 import { URL } from 'node:url';
 
 import { Server, SOCKS_PROTOCOLS } from './server.js';
+import { validateListenPort } from './utils/validate_listen_port.js';
 
 // Dictionary, key is value returned from anonymizeProxy(), value is Server instance.
 const anonymizedProxyUrlToServer: Record<string, Server> = {};
 
 export interface AnonymizeProxyOptions {
     url: string;
-    port: number;
+    port?: number;
     ignoreProxyCertificate?: boolean;
 }
 
@@ -30,13 +31,9 @@ export const anonymizeProxy = async (
         proxyUrl = options;
     } else {
         proxyUrl = options.url;
-        port = options.port;
+        port = options.port ?? 0;
 
-        if (port < 0 || port > 65535) {
-            throw new Error(
-                'Invalid "port" option: only values equals or between 0-65535 are valid',
-            );
-        }
+        validateListenPort(port);
 
         if (options.ignoreProxyCertificate !== undefined) {
             ignoreProxyCertificate = options.ignoreProxyCertificate;

--- a/src/tcp_tunnel_tools.ts
+++ b/src/tcp_tunnel_tools.ts
@@ -2,8 +2,21 @@ import net from 'node:net';
 import { URL } from 'node:url';
 
 import { chain } from './chain.js';
+import { validateListenPort } from './utils/validate_listen_port.js';
 
 const runningServers: Record<string, { server: net.Server, connections: Set<net.Socket> }> = {};
+
+// The tunnel does not authenticate its clients and forwards the proxyUrl credentials
+// upstream, so it must not be reachable off the local machine by default.
+const DEFAULT_LISTEN_HOSTNAME = '127.0.0.1';
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '::1', '0:0:0:0:0:0:0:1']);
+
+const isLoopbackHostname = (hostname: string) => {
+    const normalized = hostname.toLowerCase();
+
+    return LOOPBACK_HOSTNAMES.has(normalized) || normalized.startsWith('127.');
+};
 
 const getAddress = (server: net.Server) => {
     const { address: host, port, family } = server.address() as net.AddressInfo;
@@ -19,6 +32,8 @@ export async function createTunnel(
     proxyUrl: string,
     targetHost: string,
     options?: {
+        port?: number;
+        hostname?: string;
         verbose?: boolean;
         ignoreProxyCertificate?: boolean;
     },
@@ -38,7 +53,20 @@ export async function createTunnel(
         throw new Error('Missing target port');
     }
 
-    const verbose = options && options.verbose;
+    const listenPort = options?.port ?? 0;
+    const listenHostname = options?.hostname || DEFAULT_LISTEN_HOSTNAME;
+
+    validateListenPort(listenPort);
+
+    if (!isLoopbackHostname(listenHostname)) {
+        process.emitWarning(
+            `The tunnel is listening on "${listenHostname}", so it may be reachable from other machines.`
+            + ' It does not authenticate its clients and forwards the proxyUrl credentials upstream.',
+            'ProxyChainSecurityWarning',
+        );
+    }
+
+    const verbose = options?.verbose ?? false;
 
     const server: net.Server & { log?: (...args: unknown[]) => void } = net.createServer();
 
@@ -79,8 +107,7 @@ export async function createTunnel(
     const promise = new Promise<string>((resolve, reject) => {
         server.once('error', reject);
 
-        // Let the system pick a random listening port
-        server.listen(0, () => {
+        server.listen(listenPort, listenHostname, () => {
             const address = getAddress(server);
 
             server.off('error', reject);

--- a/src/utils/validate_listen_port.ts
+++ b/src/utils/validate_listen_port.ts
@@ -1,3 +1,4 @@
+/** Throws if `port` is not a valid TCP port number (0-65535). */
 export const validateListenPort = (port: number): void => {
     if (!Number.isInteger(port) || port < 0 || port > 65535) {
         throw new Error(`The "port" option must be an integer between 0 and 65535 (was ${port})`);

--- a/src/utils/validate_listen_port.ts
+++ b/src/utils/validate_listen_port.ts
@@ -1,0 +1,5 @@
+export const validateListenPort = (port: number): void => {
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error(`The "port" option must be an integer between 0 and 65535 (was ${port})`);
+    }
+};

--- a/test/e2e/tcp_tunnel.js
+++ b/test/e2e/tcp_tunnel.js
@@ -2,6 +2,7 @@ import net from 'node:net';
 import { expect, assert } from 'chai';
 import http from 'node:http';
 import proxy from 'proxy';
+import portastic from 'portastic';
 
 import { createTunnel, closeTunnel } from '../../src/index.js';
 import { expectThrowsAsync } from '../utils/throws_async.js';
@@ -22,8 +23,8 @@ const serverListen = (server, port) => new Promise((resolve, reject) => {
     });
 });
 
-const connect = (port) => new Promise((resolve, reject) => {
-    const socket = net.connect({ port }, (err) => {
+const connect = (host, port) => new Promise((resolve, reject) => {
+    const socket = net.connect({ host, port }, (err) => {
         if (err) return reject(err);
         return resolve(socket);
     });
@@ -49,6 +50,70 @@ describe('tcp_tunnel.createTunnel', () => {
         expectThrowsAsync(async () => { await createTunnel('http://user:password@whatever.com:12', 'whatever'); }, 'Missing target port');
         expectThrowsAsync(async () => { await createTunnel('http://user:password@whatever.com:12', 'whatever:'); }, 'Missing target port');
         expectThrowsAsync(async () => { await createTunnel('http://user:password@whatever.com:12', ':whatever'); }, /Invalid URL/);
+    });
+    it('throws error if the port option is not a valid port number', async () => {
+        const proxyUrl = 'http://user:password@whatever.com:12';
+        const invalidPorts = [-1, 65536, 1.5, '8080'];
+
+        for (const port of invalidPorts) {
+            await expectThrowsAsync(
+                async () => { await createTunnel(proxyUrl, 'localhost:9000', { port }); },
+                'The "port" option must be an integer between 0 and 65535',
+            );
+        }
+    });
+    // Regression guard for GHSA-5vwf-g8jp-pgj3: createTunnel() used to bind the unspecified address.
+    describe('listener address', () => {
+        // createTunnel() only parses the URLs, it never dials them, so these need no servers.
+        const PROXY_URL = 'http://owner:s3cr3t@127.0.0.1:1';
+        const TARGET = '127.0.0.1:1';
+
+        let tunnel;
+
+        afterEach(async () => {
+            if (tunnel) await closeTunnel(tunnel, true);
+            tunnel = undefined;
+        });
+
+        it('binds a loopback address by default', async () => {
+            tunnel = await createTunnel(PROXY_URL, TARGET);
+
+            expect(tunnel).to.match(/^127\.0\.0\.1:\d+$/);
+        });
+        it('honours an explicit IPv6 hostname and brackets the returned endpoint', async () => {
+            tunnel = await createTunnel(PROXY_URL, TARGET, { hostname: '::1' });
+
+            expect(tunnel).to.match(/^\[::1\]:\d+$/);
+        });
+        it('warns when binding a non-loopback address, but still binds it', async () => {
+            const warnings = [];
+            const onWarning = (warning) => warnings.push(warning);
+            process.on('warning', onWarning);
+
+            try {
+                tunnel = await createTunnel(PROXY_URL, TARGET, { hostname: '0.0.0.0' });
+            } finally {
+                // Warnings are emitted on the next tick.
+                await new Promise((resolve) => setImmediate(resolve));
+                process.off('warning', onWarning);
+            }
+
+            expect(tunnel).to.match(/^0\.0\.0\.0:\d+$/);
+            expect(warnings.map((warning) => warning.name)).to.include('ProxyChainSecurityWarning');
+        });
+        it('falls back to loopback when the hostname is blank', async () => {
+            tunnel = await createTunnel(PROXY_URL, TARGET, { hostname: '' });
+
+            expect(tunnel).to.match(/^127\.0\.0\.1:\d+$/);
+        });
+        it('honours an explicit port', async () => {
+            const [port] = await portastic.find({ min: 50750, max: 51000 });
+            assert.isDefined(port, 'no free port in the test range');
+
+            tunnel = await createTunnel(PROXY_URL, TARGET, { port });
+
+            expect(tunnel).to.equal(`127.0.0.1:${port}`);
+        });
     });
     it('correctly tunnels to tcp service and then is able to close the connection', () => {
         const proxyServerConnections = [];
@@ -129,9 +194,11 @@ describe('tcp_tunnel.createTunnel', () => {
             .then((newTunnel) => {
                 tunnel = newTunnel;
 
-                const { port } = new URL(`connect://${newTunnel}`);
+                // Dial the host createTunnel() returned, not `localhost` - that
+                // resolves to whichever family getaddrinfo happens to prefer.
+                const { hostname, port } = new URL(`connect://${newTunnel}`);
 
-                return connect(port);
+                return connect(hostname, port);
             })
             .then((connection) => {
                 connection.setEncoding('utf8');


### PR DESCRIPTION
 `createTunnel()` called `server.listen(0)` without a host, so the tunnel bound the
  unspecified address (`::` / `0.0.0.0`). Any peer that could reach the host could tunnel
  to `targetHost` using those credentials.

  GHSA-5vwf-g8jp-pgj3, #660.

  ## Changes:
  - `createTunnel()` listens on `127.0.0.1` by default. The `port` and `hostname` options
    documented in the README work again — they were dropped from the implementation in v2.0.0.
    Pass `hostname: '0.0.0.0'` to opt back into the old binding.
  - Warns when bound to a non-loopback address.
  - Tests for the listener address.
  - additional change - anonymizeProxy has optional port and defaults to 0 (random port)

  Behavior change: the returned endpoint is `127.0.0.1:<port>` instead of `0.0.0.0:<port>`.
  
  
  I have also pushed a branch `tmp/tunnel-connect-fix-with-repro` with repro, that demonstrates that the fix works.
