### PR TITLE
fix: remove outdated proxy package workaround

### DIFF
--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -292,16 +292,6 @@ const createTestSuite = ({
                         upstreamProxyPort = takePort(freePorts);
                         upstreamProxyServer = createProxy(upstreamProxyHttpServer);
                         listenOnPort(upstreamProxyServer, upstreamProxyPort).then(() => resolve(), reject);
-
-                        // This is a workaround to a buggy implementation of "proxy" package. On Node 10+,
-                        // the socket sometimes emits ECONNRESET error, which would break the test.
-                        // We just swallow it.
-                        upstreamProxyServer.on('connect', (_req: http.IncomingMessage, socket: net.Socket) => {
-                            socket.on('error', (err: NodeJS.ErrnoException) => {
-                                if (err.code === 'ECONNRESET') return;
-                                throw err;
-                            });
-                        });
                     });
                 }
             }).then(async () => {


### PR DESCRIPTION
Removes unnecessary proxy package workaround that creates test flakiness: https://github.com/apify/proxy-chain/actions/runs/33449396551/job/99675639823?pr=694