### PR TITLE
fix: set explicit rootDir in typescript config

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,8 @@
 {
 	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
 	"include": [
 		"src",
 		"test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
     "extends": "@apify/tsconfig",
     "compilerOptions": {
         "outDir": "dist",
+        "rootDir": "src",
+        "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "target": "ES2022",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "noEmit": true,
+        "rootDir": ".",
         // Inherited `incremental` would drop a .tsbuildinfo into the build output dir.
         "incremental": false,
         // got-scraping's own types pull in got-cjs, which imports the untyped


### PR DESCRIPTION
Fixes TS build after version bump.
[https://github.com/apify/proxy-chain/actions/runs/33509195858/job/99860888683](https://github.com/apify/proxy-chain/actions/runs/33509195858/job/99860888683)